### PR TITLE
Optimizations for q40, q80, q5k, fix Cosmos VLM prefill

### DIFF
--- a/ggml/src/ggml-cuda/mmq-load-tiles.cuh
+++ b/ggml/src/ggml-cuda/mmq-load-tiles.cuh
@@ -632,6 +632,89 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
     }
 }
 
+#if defined(GGML_USE_HIP) && defined(RDNA3_5)
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_prefetch_tiles_q8_0_rdna35(
+        const char * __restrict__ x, const int kbx0, const int i_max, const int stride,
+        int (&qs_cache)[2 * ggml_cuda_mmq_get_I(type, J, fallback)/
+                       (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        float (&d_cache)[4]) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads  = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps    = nthreads / warp_size;
+    constexpr int I         = ggml_cuda_mmq_get_I(type, J, fallback);
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q8_0 MMQ configuration");
+
+    const int txi  = threadIdx.x;
+    const int kbx  = txi / QI8_0;
+    const int kqsx = txi % QI8_0;
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        int i = i0 + threadIdx.y;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbx;
+        qs_cache[2*(i0/nwarps) + 0] = get_int_b2(bxi[0].qs,                   kqsx);
+        qs_cache[2*(i0/nwarps) + 1] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs, kqsx);
+    }
+
+    constexpr int blocks_per_tile_x_row = 2*MMQ_TILE_NE_K / QI8_0;
+    constexpr int scale_rows_per_warp   = warp_size / blocks_per_tile_x_row;
+    const int kbxd = threadIdx.x % blocks_per_tile_x_row;
+    int d_idx = 0;
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps * scale_rows_per_warp) {
+        int i = i0 + threadIdx.y * scale_rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbxd;
+        d_cache[d_idx++] = bxi->d;
+    }
+
+    asm volatile("" ::: "memory");
+}
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_store_tiles_q8_0_rdna35(
+        int * __restrict__ x_tile,
+        const int (&qs_cache)[2 * ggml_cuda_mmq_get_I(type, J, fallback)/
+                              (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        const float (&d_cache)[4]) {
+    constexpr int warp_size   = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads    = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps      = nthreads / warp_size;
+    constexpr int I           = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int sram_stride = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q8_0 MMQ configuration");
+
+    int   * x_qs = x_tile;
+    float * x_df = (float *) (x_tile + 2*MMQ_TILE_NE_K);
+    const int txi = threadIdx.x;
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        const int i = i0 + threadIdx.y;
+        x_qs[i*sram_stride + 0             + txi] = qs_cache[2*(i0/nwarps) + 0];
+        x_qs[i*sram_stride + MMQ_TILE_NE_K + txi] = qs_cache[2*(i0/nwarps) + 1];
+    }
+
+    constexpr int blocks_per_tile_x_row = 2*MMQ_TILE_NE_K / QI8_0;
+    constexpr int scale_rows_per_warp   = warp_size / blocks_per_tile_x_row;
+    const int kbxd = threadIdx.x % blocks_per_tile_x_row;
+    int d_idx = 0;
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps * scale_rows_per_warp) {
+        const int i = i0 + threadIdx.y * scale_rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+        x_df[i*sram_stride + kbxd] = d_cache[d_idx++];
+    }
+}
+#endif // defined(GGML_USE_HIP) && defined(RDNA3_5)
+
 // ---------------------------------------------------------------------------------------------
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_load_tiles_q2_K(

--- a/ggml/src/ggml-cuda/mmq-load-tiles.cuh
+++ b/ggml/src/ggml-cuda/mmq-load-tiles.cuh
@@ -263,6 +263,90 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
     }
 }
 
+#if defined(GGML_USE_HIP) && defined(RDNA3_5)
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_prefetch_tiles_q4_0_rdna35(
+        const char * __restrict__ x, const int kbx0, const int i_max, const int stride,
+        int (&qs_cache)[ggml_cuda_mmq_get_I(type, J, fallback)/
+                       (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        float (&d_cache)[4]) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads  = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps    = nthreads / warp_size;
+    constexpr int I         = ggml_cuda_mmq_get_I(type, J, fallback);
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q4_0 MMQ configuration");
+
+    const int kbx  = threadIdx.x / QI4_0;
+    const int kqsx = threadIdx.x % QI4_0;
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        int i = i0 + threadIdx.y;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q4_0 * bxi = (const block_q4_0 *) x + kbx0 + i*stride + kbx;
+        qs_cache[i0/nwarps] = get_int_b2(bxi->qs, kqsx);
+    }
+
+    constexpr int blocks_per_tile_x_row = MMQ_TILE_NE_K / QI4_0;
+    constexpr int scale_rows_per_warp   = warp_size / blocks_per_tile_x_row;
+    const int kbxd = threadIdx.x % blocks_per_tile_x_row;
+    int d_idx = 0;
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps * scale_rows_per_warp) {
+        int i = i0 + threadIdx.y * scale_rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q4_0 * bxi = (const block_q4_0 *) x + kbx0 + i*stride + kbxd;
+        d_cache[d_idx++] = bxi->d;
+    }
+
+    asm volatile("" ::: "memory");
+}
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_store_tiles_q4_0_rdna35(
+        int * __restrict__ x_tile,
+        const int (&qs_cache)[ggml_cuda_mmq_get_I(type, J, fallback)/
+                              (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        const float (&d_cache)[4]) {
+    constexpr int warp_size   = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads    = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps      = nthreads / warp_size;
+    constexpr int I           = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int sram_stride = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q4_0 MMQ configuration");
+
+    int   * x_qs = x_tile;
+    float * x_df = (float *) (x_qs + 2*MMQ_TILE_NE_K);
+    const int txi  = threadIdx.x;
+    const int kbx  = txi / QI4_0;
+    const int kqsx = txi % QI4_0;
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        const int i = i0 + threadIdx.y;
+        const int qs0 = qs_cache[i0/nwarps];
+        x_qs[i*sram_stride + kbx*(2*QI4_0) + kqsx + 0]     = __vsubss4((qs0 >> 0) & 0x0F0F0F0F, 0x08080808);
+        x_qs[i*sram_stride + kbx*(2*QI4_0) + kqsx + QI4_0] = __vsubss4((qs0 >> 4) & 0x0F0F0F0F, 0x08080808);
+    }
+
+    constexpr int blocks_per_tile_x_row = MMQ_TILE_NE_K / QI4_0;
+    constexpr int scale_rows_per_warp   = warp_size / blocks_per_tile_x_row;
+    const int kbxd = threadIdx.x % blocks_per_tile_x_row;
+    int d_idx = 0;
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps * scale_rows_per_warp) {
+        const int i = i0 + threadIdx.y * scale_rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+        x_df[i*sram_stride + kbxd] = d_cache[d_idx++];
+    }
+}
+#endif // defined(GGML_USE_HIP) && defined(RDNA3_5)
+
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_load_tiles_q4_1(
         const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
     constexpr int warp_size   = ggml_cuda_get_physical_warp_size();

--- a/ggml/src/ggml-cuda/mmq-load-tiles.cuh
+++ b/ggml/src/ggml-cuda/mmq-load-tiles.cuh
@@ -1017,6 +1017,166 @@ static __device__ __forceinline__ void ggml_cuda_mmq_store_tiles_q4_K_rdna35(
         x_dm[i*sram_stride + sizeof(int)*ksc + l] = dm*make_half2(sc8[l], m8[l]);
     }
 }
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_load_tiles_q5_K_rdna35(
+        const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+    constexpr int warp_size   = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads    = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int I           = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int sram_stride = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q5_K MMQ configuration");
+
+    int   * x_qs = (int   *) x_tile;
+    half2 * x_dm = (half2 *) (x_qs + 2*MMQ_TILE_NE_K);
+
+    const int linear_tid = threadIdx.y*warp_size + threadIdx.x;
+    int i = linear_tid/2;
+    if (fallback) {
+        i = min(i, i_max);
+    }
+
+    const block_q5_K * bxi = (const block_q5_K *) x + kbx0 + i*stride;
+    const int * scales = (const int *) bxi->scales;
+    const int ksc = linear_tid % 2;
+    const int sc32 = unpack_scales_q45_K(scales, ksc);
+    const int  m32 = unpack_scales_q45_K(scales, ksc + 2);
+    const uint8_t * sc8 = (const uint8_t *) &sc32;
+    const uint8_t *  m8 = (const uint8_t *) &m32;
+    const half2 dm = bxi->dm * make_half2(1.0f, -1.0f);
+
+#pragma unroll
+    for (int l = 0; l < int(sizeof(int)); ++l) {
+        x_dm[i*sram_stride + sizeof(int)*ksc + l] = dm*make_half2(sc8[l], m8[l]);
+    }
+
+    const int txi = threadIdx.x;
+    const int kqs = 16*(txi/8) + txi%8;
+    const int qh_shift0 = 2*(txi/8);
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nthreads/warp_size) {
+        int row = i0 + threadIdx.y;
+        if (fallback) {
+            row = min(row, i_max);
+        }
+
+        const block_q5_K * bxq = (const block_q5_K *) x + kbx0 + row*stride;
+        const int qs = ((const int *) bxq->qs)[txi];
+        const int qh = ((const int *) bxq->qh)[txi % (QI5_K/4)];
+        int * row_qs = x_qs + row*sram_stride;
+        row_qs[kqs]   = (qs & 0x0F0F0F0F) | (((qh >> (qh_shift0 + 0)) << 4) & 0x10101010);
+        row_qs[kqs+8] = ((qs >> 4) & 0x0F0F0F0F) | (((qh >> (qh_shift0 + 1)) << 4) & 0x10101010);
+    }
+}
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_prefetch_tiles_q5_K_rdna35(
+        const char * __restrict__ x, const int kbx0, const int i_max, const int stride,
+        int (&qs_cache)[ggml_cuda_mmq_get_I(type, J, fallback)/
+                       (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        int (&qh_cache)[ggml_cuda_mmq_get_I(type, J, fallback)*(QI5_K/4)/
+                       ggml_cuda_mmq_get_nthreads(type, J, fallback)],
+        int (&scales_cache)[3], half2 & dm_cache) {
+    constexpr int warp_size       = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads        = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps          = nthreads / warp_size;
+    constexpr int I               = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int qh_words_per_row = QI5_K/4;
+    constexpr int qh_cache_size    = I*qh_words_per_row/nthreads;
+    constexpr int rows_per_warp    = I/nwarps;
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q5_K MMQ configuration");
+    static_assert(qh_cache_size*warp_size == rows_per_warp*qh_words_per_row,
+                  "Q5_K high bits must be distributed evenly across the warp");
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        int i = i0 + threadIdx.y;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q5_K * bxi = (const block_q5_K *) x + kbx0 + i*stride;
+        qs_cache[i0/nwarps] = ((const int *) bxi->qs)[threadIdx.x];
+    }
+
+#pragma unroll
+    for (int l = 0; l < qh_cache_size; ++l) {
+        const int qh_linear = l*warp_size + threadIdx.x;
+        int i = (qh_linear/qh_words_per_row)*nwarps + threadIdx.y;
+        if constexpr (fallback) {
+            i = min(i, i_max);
+        }
+
+        const block_q5_K * bxi = (const block_q5_K *) x + kbx0 + i*stride;
+        qh_cache[l] = ((const int *) bxi->qh)[qh_linear % qh_words_per_row];
+    }
+
+    int i = (threadIdx.y*warp_size + threadIdx.x)/2;
+    if constexpr (fallback) {
+        i = min(i, i_max);
+    }
+
+    const block_q5_K * bxi = (const block_q5_K *) x + kbx0 + i*stride;
+#pragma unroll
+    for (int l = 0; l < 3; ++l) {
+        scales_cache[l] = ((const int *) bxi->scales)[l];
+    }
+    dm_cache = bxi->dm;
+
+    asm volatile("" ::: "memory");
+}
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_store_tiles_q5_K_rdna35(
+        int * __restrict__ x_tile,
+        const int (&qs_cache)[ggml_cuda_mmq_get_I(type, J, fallback)/
+                              (ggml_cuda_mmq_get_nthreads(type, J, fallback)/ggml_cuda_get_physical_warp_size())],
+        const int (&qh_cache)[ggml_cuda_mmq_get_I(type, J, fallback)*(QI5_K/4)/
+                              ggml_cuda_mmq_get_nthreads(type, J, fallback)],
+        const int (&scales_cache)[3], const half2 dm_cache) {
+    constexpr int warp_size        = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads         = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps           = nthreads / warp_size;
+    constexpr int I                = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int sram_stride      = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+    constexpr int qh_words_per_row = QI5_K/4;
+    constexpr int qh_rows_per_slot = warp_size/qh_words_per_row;
+    static_assert(warp_size == 32 && nthreads == 128 && I == 64, "unexpected RDNA3.5 Q5_K MMQ configuration");
+
+    int * x_qs = x_tile;
+    const int txi = threadIdx.x;
+    const int kqs = 16*(txi/8) + txi%8;
+    const int qh_shift0 = 2*(txi/8);
+
+#pragma unroll
+    for (int i0 = 0; i0 < I; i0 += nwarps) {
+        const int row_in_warp = i0/nwarps;
+        const int qh_slot = row_in_warp/qh_rows_per_slot;
+        const int qh_src_lane = (row_in_warp % qh_rows_per_slot)*qh_words_per_row + txi%qh_words_per_row;
+        const int qs = qs_cache[row_in_warp];
+        const int qh = __shfl_sync(0xFFFFFFFF, qh_cache[qh_slot], qh_src_lane, warp_size);
+        const int i = i0 + threadIdx.y;
+        int * row_qs = x_qs + i*sram_stride;
+        row_qs[kqs]   = (qs & 0x0F0F0F0F) | (((qh >> (qh_shift0 + 0)) << 4) & 0x10101010);
+        row_qs[kqs+8] = ((qs >> 4) & 0x0F0F0F0F) | (((qh >> (qh_shift0 + 1)) << 4) & 0x10101010);
+    }
+
+    half2 * x_dm = (half2 *) (x_qs + 2*MMQ_TILE_NE_K);
+    const int linear_tid = threadIdx.y*warp_size + threadIdx.x;
+    const int i = linear_tid/2;
+    const int ksc = linear_tid%2;
+    const int sc32 = unpack_scales_q45_K(scales_cache, ksc);
+    const int  m32 = unpack_scales_q45_K(scales_cache, ksc + 2);
+    const uint8_t * sc8 = (const uint8_t *) &sc32;
+    const uint8_t *  m8 = (const uint8_t *) &m32;
+    const half2 dm = dm_cache * make_half2(1.0f, -1.0f);
+
+#pragma unroll
+    for (int l = 0; l < int(sizeof(int)); ++l) {
+        x_dm[i*sram_stride + sizeof(int)*ksc + l] = dm*make_half2(sc8[l], m8[l]);
+    }
+}
 #endif
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_load_tiles_q4_K(
@@ -1137,6 +1297,11 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_load_tiles_q5_K(
         const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+#if defined(RDNA3_5)
+    ggml_cuda_mmq_load_tiles_q5_K_rdna35<type, J, fallback>(x, x_tile, kbx0, i_max, stride);
+    return;
+#endif
+
     constexpr int warp_size   = ggml_cuda_get_physical_warp_size();
     constexpr int nwarps      = ggml_cuda_mmq_get_nthreads(type, J, fallback) / warp_size;
     constexpr int I           = ggml_cuda_mmq_get_I(type, J, fallback);

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1070,6 +1070,80 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna3
     }
     ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(x, y, sum, k00);
 }
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_0_q8_1_mma_rdna35(
+        const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
+    if constexpr (type == GGML_TYPE_Q4_0 && J == 128) {
+        constexpr data_layout input_layout = get_input_data_layout();
+        typedef tile<16,  8, int, input_layout>        tile_A;
+        typedef tile<16,  8, int, input_layout>        tile_B;
+        typedef tile<16, 16, int, DATA_LAYOUT_J_MAJOR> tile_C;
+
+        constexpr int I             = ggml_cuda_mmq_get_I(type, J, fallback);
+        constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+        constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
+        constexpr int ntx           = rows_per_warp/tile_C::I;
+        constexpr int ntiles        = J/tile_C::J;
+        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q4_0 J128 configuration");
+
+        const int   * x_qs = (const int   *) x;
+        const float * x_df = (const float *) x_qs + 2*MMQ_TILE_NE_K;
+        const int   * y_qs = (const int   *) y + 4;
+        const half2 * y_ds = (const half2 *) y;
+
+        const int i0 = threadIdx.y*rows_per_warp;
+
+        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
+            const int k0 = k00 + k01;
+
+            tile_A A;
+            load_ldmatrix(A, x_qs + i0*sram_stride + k0, sram_stride);
+
+            tile_B B[ntiles];
+            tile_C C[ntiles];
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                load_ldmatrix(B[jb], y_qs + jb*tile_C::J*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
+                ggml_cuda_mmq_mma_q4_K_rdna35_low(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+            float dA[tile_C::ne];
+            float dB[ntiles];
+#pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int i = i0 + tile_C::get_i(l);
+                dA[l] = x_df[i*sram_stride + k0/QI8_0];
+            }
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                const int j = jb*tile_C::J + tile_C::get_j(0);
+                dB[jb] = __low2float(y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                ggml_cuda_mmq_mma_q4_K_rdna35_high(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+#pragma unroll
+                for (int l = 0; l < tile_C::ne; ++l) {
+                    sum[jb*tile_C::ne + l] += C[jb].x[l]*dA[l]*dB[jb];
+                }
+            }
+        }
+        return;
+    }
+    ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_DS4>(x, y, sum, k00);
+}
 #endif
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q5_K_q8_1_dp4a(

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -975,7 +975,7 @@ static __device__ __forceinline__ void ggml_cuda_mmq_mma_q4_K_rdna35_high(
 template <ggml_type type, int J, bool fallback>
 static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna35(
         const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    if constexpr (type == GGML_TYPE_Q4_K && J == 128) {
+    if constexpr ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q5_K) && J == 128) {
         constexpr data_layout input_layout = get_input_data_layout();
         typedef tile<16,  8, int, input_layout>        tile_A;
         typedef tile<16,  8, int, input_layout>        tile_B;
@@ -986,7 +986,7 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna3
         constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
         constexpr int ntx           = rows_per_warp/tile_C::I;
         constexpr int ntiles        = J/tile_C::J;
-        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q4_K J128 configuration");
+        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q4_K/Q5_K ntx=1 configuration");
 
         const int   * x_qs = (const int   *) x;
         const half2 * x_dm = (const half2 *) x_qs + 2*MMQ_TILE_NE_K;

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1144,6 +1144,80 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_0_q8_1_mma_rdna3
     }
     ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_DS4>(x, y, sum, k00);
 }
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma_rdna35(
+        const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
+    if constexpr (type == GGML_TYPE_Q8_0 && J == 128) {
+        constexpr data_layout input_layout = get_input_data_layout();
+        typedef tile<16,  8, int, input_layout>        tile_A;
+        typedef tile<16,  8, int, input_layout>        tile_B;
+        typedef tile<16, 16, int, DATA_LAYOUT_J_MAJOR> tile_C;
+
+        constexpr int I             = ggml_cuda_mmq_get_I(type, J, fallback);
+        constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+        constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
+        constexpr int ntx           = rows_per_warp/tile_C::I;
+        constexpr int ntiles        = J/tile_C::J;
+        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q8_0 J128 configuration");
+
+        const int   * x_qs = (const int   *) x;
+        const float * x_df = (const float *) x_qs + 2*MMQ_TILE_NE_K;
+        const int   * y_qs = (const int   *) y + 4;
+        const float * y_df = (const float *) y;
+
+        const int i0 = threadIdx.y*rows_per_warp;
+
+        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
+            const int k0 = k00 + k01;
+
+            tile_A A;
+            load_ldmatrix(A, x_qs + i0*sram_stride + k0, sram_stride);
+
+            tile_B B[ntiles];
+            tile_C C[ntiles];
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                load_ldmatrix(B[jb], y_qs + jb*tile_C::J*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
+                ggml_cuda_mmq_mma_q4_K_rdna35_low(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+            float dA[tile_C::ne];
+            float dB[ntiles];
+#pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int i = i0 + tile_C::get_i(l);
+                dA[l] = x_df[i*sram_stride + k0/QI8_0];
+            }
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                const int j = jb*tile_C::J + tile_C::get_j(0);
+                dB[jb] = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                ggml_cuda_mmq_mma_q4_K_rdna35_high(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+#pragma unroll
+                for (int l = 0; l < tile_C::ne; ++l) {
+                    sum[jb*tile_C::ne + l] += C[jb].x[l]*dA[l]*dB[jb];
+                }
+            }
+        }
+        return;
+    }
+    ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_D4>(x, y, sum, k00);
+}
 #endif
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q5_K_q8_1_dp4a(

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -139,6 +139,37 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
     }
 }
 
+#if defined(RDNA3_5)
+// One 16x16x16 IU8 WMMA over the low or high half of the A/B tiles. Splitting the two
+// halves lets a caller issue every tile's low half, load the scales, then issue the high
+// halves, so the MMAs are not serialised behind the scale loads.
+static __device__ __forceinline__ void ggml_cuda_mmq_mma_q4_K_rdna35_low(
+        tile<16, 16, int, DATA_LAYOUT_J_MAJOR> & D,
+        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & A,
+        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & B) {
+    using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    int32x8_t * acc = (int32x8_t *) D.x;
+    const int32x4_t * a_vec = (const int32x4_t *) A.x;
+    const int32x4_t * b_vec = (const int32x4_t *) B.x;
+    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[0], true, b_vec[0], acc[0], true);
+}
+
+static __device__ __forceinline__ void ggml_cuda_mmq_mma_q4_K_rdna35_high(
+        tile<16, 16, int, DATA_LAYOUT_J_MAJOR> & D,
+        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & A,
+        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & B) {
+    using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    int32x8_t * acc = (int32x8_t *) D.x;
+    const int32x4_t * a_vec = (const int32x4_t *) A.x;
+    const int32x4_t * b_vec = (const int32x4_t *) B.x;
+    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[1], true, b_vec[1], acc[0], true);
+}
+#endif // defined(RDNA3_5)
+
 template <ggml_type type, int J, bool fallback, mmq_q8_1_ds_layout ds_layout>
 static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
@@ -162,6 +193,68 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+#if defined(RDNA3_5)
+    // With a single x minitile per warp the generic schedule below stalls once per j-tile
+    // waiting for that tile's scales. Instead issue every tile's low WMMA half, load all
+    // the scales, then issue the high halves, so the MMA pipe stays busy across the loads.
+    if constexpr (J == 128 && ntx == 1) {
+        constexpr int ntiles = J/tile_C::J;
+        static_assert(I == 64, "unexpected RDNA3.5 J=128 tile height");
+
+        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
+            const int k0 = k00 + k01;
+
+            tile_A A;
+            load_ldmatrix(A, x_qs + i0*sram_stride + k0, sram_stride);
+
+            tile_B B[ntiles];
+            tile_C C[ntiles];
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                load_ldmatrix(B[jb], y_qs + jb*tile_C::J*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
+                ggml_cuda_mmq_mma_q4_K_rdna35_low(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+            float dA[tile_C::ne];
+            float dB[ntiles];
+#pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int i = i0 + tile_C::get_i(l);
+                dA[l] = x_df[i*sram_stride + k0/QI8_0];
+            }
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                const int j = jb*tile_C::J + tile_C::get_j(0);
+                if constexpr (ds_layout == MMQ_Q8_1_DS_LAYOUT_D4) {
+                    dB[jb] = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
+                } else {
+                    dB[jb] = __low2float(y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+                }
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+                ggml_cuda_mmq_mma_q4_K_rdna35_high(C[jb], A, B[jb]);
+            }
+
+            __builtin_amdgcn_sched_barrier(0);
+
+#pragma unroll
+            for (int jb = 0; jb < ntiles; ++jb) {
+#pragma unroll
+                for (int l = 0; l < tile_C::ne; ++l) {
+                    sum[jb*tile_C::ne + l] += C[jb].x[l]*dA[l]*dB[jb];
+                }
+            }
+        }
+        return;
+    }
+#endif // defined(RDNA3_5)
 
     for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
         const int k0 = k00 + k01;
@@ -946,32 +1039,6 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 }
 
 #if defined(RDNA3_5)
-static __device__ __forceinline__ void ggml_cuda_mmq_mma_q4_K_rdna35_low(
-        tile<16, 16, int, DATA_LAYOUT_J_MAJOR> & D,
-        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & A,
-        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & B) {
-    using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
-    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
-
-    int32x8_t * acc = (int32x8_t *) D.x;
-    const int32x4_t * a_vec = (const int32x4_t *) A.x;
-    const int32x4_t * b_vec = (const int32x4_t *) B.x;
-    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[0], true, b_vec[0], acc[0], true);
-}
-
-static __device__ __forceinline__ void ggml_cuda_mmq_mma_q4_K_rdna35_high(
-        tile<16, 16, int, DATA_LAYOUT_J_MAJOR> & D,
-        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & A,
-        const tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED> & B) {
-    using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
-    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
-
-    int32x8_t * acc = (int32x8_t *) D.x;
-    const int32x4_t * a_vec = (const int32x4_t *) A.x;
-    const int32x4_t * b_vec = (const int32x4_t *) B.x;
-    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[1], true, b_vec[1], acc[0], true);
-}
-
 template <ggml_type type, int J, bool fallback>
 static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna35(
         const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
@@ -1071,153 +1138,6 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna3
     ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(x, y, sum, k00);
 }
 
-template <ggml_type type, int J, bool fallback>
-static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q4_0_q8_1_mma_rdna35(
-        const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    if constexpr (type == GGML_TYPE_Q4_0 && J == 128) {
-        constexpr data_layout input_layout = get_input_data_layout();
-        typedef tile<16,  8, int, input_layout>        tile_A;
-        typedef tile<16,  8, int, input_layout>        tile_B;
-        typedef tile<16, 16, int, DATA_LAYOUT_J_MAJOR> tile_C;
-
-        constexpr int I             = ggml_cuda_mmq_get_I(type, J, fallback);
-        constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
-        constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
-        constexpr int ntx           = rows_per_warp/tile_C::I;
-        constexpr int ntiles        = J/tile_C::J;
-        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q4_0 J128 configuration");
-
-        const int   * x_qs = (const int   *) x;
-        const float * x_df = (const float *) x_qs + 2*MMQ_TILE_NE_K;
-        const int   * y_qs = (const int   *) y + 4;
-        const half2 * y_ds = (const half2 *) y;
-
-        const int i0 = threadIdx.y*rows_per_warp;
-
-        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
-            const int k0 = k00 + k01;
-
-            tile_A A;
-            load_ldmatrix(A, x_qs + i0*sram_stride + k0, sram_stride);
-
-            tile_B B[ntiles];
-            tile_C C[ntiles];
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                load_ldmatrix(B[jb], y_qs + jb*tile_C::J*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
-                ggml_cuda_mmq_mma_q4_K_rdna35_low(C[jb], A, B[jb]);
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-            float dA[tile_C::ne];
-            float dB[ntiles];
-#pragma unroll
-            for (int l = 0; l < tile_C::ne; ++l) {
-                const int i = i0 + tile_C::get_i(l);
-                dA[l] = x_df[i*sram_stride + k0/QI8_0];
-            }
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                const int j = jb*tile_C::J + tile_C::get_j(0);
-                dB[jb] = __low2float(y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                ggml_cuda_mmq_mma_q4_K_rdna35_high(C[jb], A, B[jb]);
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-#pragma unroll
-                for (int l = 0; l < tile_C::ne; ++l) {
-                    sum[jb*tile_C::ne + l] += C[jb].x[l]*dA[l]*dB[jb];
-                }
-            }
-        }
-        return;
-    }
-    ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_DS4>(x, y, sum, k00);
-}
-
-template <ggml_type type, int J, bool fallback>
-static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma_rdna35(
-        const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    if constexpr (type == GGML_TYPE_Q8_0 && J == 128) {
-        constexpr data_layout input_layout = get_input_data_layout();
-        typedef tile<16,  8, int, input_layout>        tile_A;
-        typedef tile<16,  8, int, input_layout>        tile_B;
-        typedef tile<16, 16, int, DATA_LAYOUT_J_MAJOR> tile_C;
-
-        constexpr int I             = ggml_cuda_mmq_get_I(type, J, fallback);
-        constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
-        constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
-        constexpr int ntx           = rows_per_warp/tile_C::I;
-        constexpr int ntiles        = J/tile_C::J;
-        static_assert(I == 64 && ntx == 1, "unexpected RDNA3.5 Q8_0 J128 configuration");
-
-        const int   * x_qs = (const int   *) x;
-        const float * x_df = (const float *) x_qs + 2*MMQ_TILE_NE_K;
-        const int   * y_qs = (const int   *) y + 4;
-        const float * y_df = (const float *) y;
-
-        const int i0 = threadIdx.y*rows_per_warp;
-
-        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_0) {
-            const int k0 = k00 + k01;
-
-            tile_A A;
-            load_ldmatrix(A, x_qs + i0*sram_stride + k0, sram_stride);
-
-            tile_B B[ntiles];
-            tile_C C[ntiles];
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                load_ldmatrix(B[jb], y_qs + jb*tile_C::J*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
-                ggml_cuda_mmq_mma_q4_K_rdna35_low(C[jb], A, B[jb]);
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-            float dA[tile_C::ne];
-            float dB[ntiles];
-#pragma unroll
-            for (int l = 0; l < tile_C::ne; ++l) {
-                const int i = i0 + tile_C::get_i(l);
-                dA[l] = x_df[i*sram_stride + k0/QI8_0];
-            }
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                const int j = jb*tile_C::J + tile_C::get_j(0);
-                dB[jb] = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-                ggml_cuda_mmq_mma_q4_K_rdna35_high(C[jb], A, B[jb]);
-            }
-
-            __builtin_amdgcn_sched_barrier(0);
-
-#pragma unroll
-            for (int jb = 0; jb < ntiles; ++jb) {
-#pragma unroll
-                for (int l = 0; l < tile_C::ne; ++l) {
-                    sum[jb*tile_C::ne + l] += C[jb].x[l]*dA[l]*dB[jb];
-                }
-            }
-        }
-        return;
-    }
-    ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_D4>(x, y, sum, k00);
-}
 #endif
 
 template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_q5_K_q8_1_dp4a(

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -181,7 +181,8 @@ struct ggml_cuda_mmq_config {
     constexpr __device__ int rows_per_warp() const {
 #if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 #if defined(RDNA3_5)
-        if ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q8_0) && J == 128) {
+        if ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q8_0 ||
+             type == GGML_TYPE_Q5_K) && J == 128) {
             return 16;
         }
         return J >= 64 && J % 32 == 0 ? 32 : 16;
@@ -875,7 +876,11 @@ static constexpr __device__ ggml_cuda_mmq_util_funcs ggml_cuda_mmq_get_util_func
             return ggml_cuda_mmq_util_funcs(
                 -1,
                 ggml_cuda_mmq_load_tiles_q5_K<type, J, fallback>,
+#if defined(RDNA3_5)
+                ggml_cuda_mmq_vec_dot_q4_K_q8_1_mma_rdna35<type, J, fallback>,
+#else
                 ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>,
+#endif
                 ggml_cuda_mmq_write_back_mma<type, J, fallback>);
         case GGML_TYPE_Q6_K:
             return ggml_cuda_mmq_util_funcs(
@@ -1747,12 +1752,11 @@ struct mmq_args {
 
 #if defined(GGML_USE_HIP)
 // RDNA3.5 dual-WG (mmq_x=64, nbytes <= smpbo/2) helps K-quants with large per-tile LDS
-// (Q6_K WMMA tuning). Block quants (Q5_0, Q8_0, Q4_0) and Q4_K prefill are faster at mmq_x=128 ntx=1.
+// (Q6_K WMMA tuning). Block quants (Q5_0, Q8_0, Q4_0) and Q4_K/Q5_K prefill are faster at mmq_x=128 ntx=1.
 static bool mmq_rdna35_dual_wg_eligible(const ggml_type type) {
     switch (type) {
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q5_K:
         case GGML_TYPE_Q6_K:
             return true;
         default:
@@ -1975,10 +1979,7 @@ void mul_mat_q_switch_J(ggml_backend_cuda_context & ctx, const mmq_args & args, 
     }
 
 #if defined(GGML_USE_HIP)
-    const bool dual_wg_type =
-        type == GGML_TYPE_Q2_K || type == GGML_TYPE_Q3_K ||
-        type == GGML_TYPE_Q5_K || type == GGML_TYPE_Q6_K;
-    if (GGML_CUDA_CC_IS_RDNA3_5(cc) && J_best > 0 && dual_wg_type) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc) && J_best > 0 && mmq_rdna35_dual_wg_eligible(type)) {
         const size_t lds_dual_wg = smpbo/2;
         if (mmq_get_nbytes_shared(ggml_cuda_mmq_get_config(type, J_best, fallback, cc), cc) > lds_dual_wg) {
             int J_dual = 0;
@@ -2020,20 +2021,20 @@ void mul_mat_q_switch_J(ggml_backend_cuda_context & ctx, const mmq_args & args, 
         }
     }
 
-    if constexpr (type == GGML_TYPE_Q4_K) {
-        constexpr int q4_k_J_default     = 128;
-        constexpr int q4_k_J_small       = 64;
-        constexpr int q4_k_m_small_max   = 1024;
-        constexpr int q4_k_ncols_pipeline = 128;
-        const bool use_q4_k_pipeline =
-            args.expert_bounds == nullptr && args.ncols_max == q4_k_ncols_pipeline;
-        if (use_q4_k_pipeline) {
-            const bool use_small = args.nrows_x <= q4_k_m_small_max;
-            const int q4_k_J = use_small ? q4_k_J_small : q4_k_J_default;
-            const ggml_cuda_mmq_config config = ggml_cuda_mmq_get_config(type, q4_k_J, fallback, cc);
+    if constexpr (type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q5_K) {
+        constexpr int qk_J_default      = 128;
+        constexpr int qk_J_small        = 64;
+        constexpr int qk_m_small_max    = 1024;
+        constexpr int qk_ncols_pipeline = 128;
+        const bool use_qk_pipeline =
+            args.expert_bounds == nullptr && args.ncols_max == qk_ncols_pipeline;
+        if (use_qk_pipeline) {
+            const bool use_small = args.nrows_x <= qk_m_small_max;
+            const int qk_J = use_small ? qk_J_small : qk_J_default;
+            const ggml_cuda_mmq_config config = ggml_cuda_mmq_get_config(type, qk_J, fallback, cc);
             if (GGML_CUDA_CC_IS_RDNA3_5(cc) &&
                 config.type != GGML_TYPE_COUNT && mmq_get_nbytes_shared(config, cc) <= smpbo) {
-                J_best = q4_k_J;
+                J_best = qk_J;
             }
         }
     }

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1109,6 +1109,56 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
             }
             __syncthreads();
         }
+    } else if constexpr (type == GGML_TYPE_Q5_K && (J == 64 || J == 128)) {
+        constexpr int qs_cache_size = I/nwarps;
+        constexpr int qh_cache_size = I*(QI5_K/4)/(nwarps*warp_size);
+
+        __syncthreads();
+        load_tiles(x, tile_x, offset_x + kb0_start, tile_x_max_i, stride_row_x);
+        __syncthreads();
+
+        for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
+            const int yk = kb0*qk/ne_block;
+            const int * by0 = y + ncols_y*yk*sz;
+            const int * by1 = y + ncols_y*(yk + 1)*sz;
+
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by0[l];
+            }
+            __syncthreads();
+            vec_dot(tile_x, tile_y, sum, 0);
+
+            __syncthreads();
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by1[l];
+            }
+            __syncthreads();
+
+            int qs_cache[qs_cache_size];
+            int qh_cache[qh_cache_size];
+            int scales_cache[3];
+            half2 dm_cache;
+            const int kb0_next = kb0 + blocks_per_iter;
+            const bool have_next = kb0_next < kb0_stop;
+            if (have_next) {
+                ggml_cuda_mmq_prefetch_tiles_q5_K_rdna35<type, J, fallback>(
+                    x, offset_x + kb0_next, tile_x_max_i, stride_row_x,
+                    qs_cache, qh_cache, scales_cache, dm_cache);
+            }
+
+            vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+
+            if (have_next) {
+                ggml_cuda_mmq_store_tiles_q5_K_rdna35<type, J, fallback>(
+                    tile_x, qs_cache, qh_cache, scales_cache, dm_cache);
+            }
+            __syncthreads();
+        }
     } else if constexpr (type == GGML_TYPE_Q4_0 && (J == 64 || J == 128)) {
         constexpr int qs_cache_size = I/nwarps;
         constexpr int d_cache_size  = 4;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1822,19 +1822,20 @@ static bool mmq_rdna35_dual_wg_eligible(const ggml_type type) {
 
 // J values that measure faster on RDNA3.5 than the width the occupancy rule picks.
 //
-// J=64 is 6-7x slower than the neighbouring widths for q8_0; the other types stay within
-// 1.05x of their best there and keep it. For MoE the compacted per-expert grid already supplies
-// the parallelism that column tiling supplies for a dense GEMM, so anything above a 32-wide tile
-// only adds padding - q8_0 excepted, whose narrow tiles are slow.
+// Dense shapes now keep the width the occupancy rule picks: q8_0 used to be widened from
+// J=64 to J=96 because J=64 was several times slower, but that was the generic ntx=2
+// schedule, which rows_per_warp() no longer selects for block quants. Without the widening
+// q8_0 avoids padding 64 valid columns into a 96-wide tile and is 27% faster there.
+//
+// For MoE the compacted per-expert grid already supplies the parallelism that column tiling
+// supplies for a dense GEMM, so anything above a 32-wide tile only adds padding - q8_0
+// excepted, whose narrow tiles are slow.
 static int mmq_rdna35_tuned_J(const ggml_type type, const bool moe, const int J_occupancy) {
     if (moe) {
         if (type == GGML_TYPE_Q8_0) {
             return J_occupancy > 32 ? 96 : J_occupancy;
         }
         return J_occupancy < 32 ? J_occupancy : 32;
-    }
-    if (J_occupancy == 64 && type == GGML_TYPE_Q8_0) {
-        return 96;
     }
     return J_occupancy;
 }

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -821,11 +821,7 @@ static constexpr __device__ ggml_cuda_mmq_util_funcs ggml_cuda_mmq_get_util_func
             return ggml_cuda_mmq_util_funcs(
                 -1,
                 ggml_cuda_mmq_load_tiles_q4_0<type, J, fallback>,
-#if defined(RDNA3_5)
-                ggml_cuda_mmq_vec_dot_q4_0_q8_1_mma_rdna35<type, J, fallback>,
-#else
                 ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_DS4>,
-#endif
                 ggml_cuda_mmq_write_back_mma<type, J, fallback>);
         case GGML_TYPE_Q4_1:
             return ggml_cuda_mmq_util_funcs(
@@ -849,11 +845,7 @@ static constexpr __device__ ggml_cuda_mmq_util_funcs ggml_cuda_mmq_get_util_func
             return ggml_cuda_mmq_util_funcs(
                 -1,
                 ggml_cuda_mmq_load_tiles_q8_0<type, J, fallback>,
-#if defined(RDNA3_5)
-                ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma_rdna35<type, J, fallback>,
-#else
                 ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_D4>,
-#endif
                 ggml_cuda_mmq_write_back_mma<type, J, fallback>);
 // ---------------------------------------------------------------------------------------------
         case GGML_TYPE_Q2_K:

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -185,6 +185,12 @@ struct ggml_cuda_mmq_config {
              type == GGML_TYPE_Q5_K) && J == 128) {
             return 16;
         }
+        // Block quants only have a batched WMMA vec_dot at J=128; at the other two widths
+        // that would take ntx=2 (J=64 and J=96, the only J>=64 multiples of 32) they fall
+        // back to the generic schedule, which is several times slower there. Keep ntx=1.
+        if ((type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q8_0) && (J == 64 || J == 96)) {
+            return 16;
+        }
         return J >= 64 && J % 32 == 0 ? 32 : 16;
 #else
         return 16;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -181,7 +181,7 @@ struct ggml_cuda_mmq_config {
     constexpr __device__ int rows_per_warp() const {
 #if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 #if defined(RDNA3_5)
-        if ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q4_0) && J == 128) {
+        if ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q8_0) && J == 128) {
             return 16;
         }
         return J >= 64 && J % 32 == 0 ? 32 : 16;
@@ -842,7 +842,11 @@ static constexpr __device__ ggml_cuda_mmq_util_funcs ggml_cuda_mmq_get_util_func
             return ggml_cuda_mmq_util_funcs(
                 -1,
                 ggml_cuda_mmq_load_tiles_q8_0<type, J, fallback>,
+#if defined(RDNA3_5)
+                ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma_rdna35<type, J, fallback>,
+#else
                 ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_D4>,
+#endif
                 ggml_cuda_mmq_write_back_mma<type, J, fallback>);
 // ---------------------------------------------------------------------------------------------
         case GGML_TYPE_Q2_K:
@@ -1143,6 +1147,53 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
             if (have_next) {
                 ggml_cuda_mmq_store_tiles_q4_0_rdna35<type, J, fallback>(
+                    tile_x, qs_cache, d_cache);
+            }
+            __syncthreads();
+        }
+    } else if constexpr (type == GGML_TYPE_Q8_0 && (J == 96 || J == 128)) {
+        constexpr int qs_cache_size = 2*(I/nwarps);
+        constexpr int d_cache_size  = 4;
+
+        __syncthreads();
+        load_tiles(x, tile_x, offset_x + kb0_start, tile_x_max_i, stride_row_x);
+        __syncthreads();
+
+        for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
+            const int yk = kb0*qk/ne_block;
+            const int * by0 = y + ncols_y*yk*sz;
+            const int * by1 = y + ncols_y*(yk + 1)*sz;
+
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by0[l];
+            }
+            __syncthreads();
+            vec_dot(tile_x, tile_y, sum, 0);
+
+            __syncthreads();
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by1[l];
+            }
+            __syncthreads();
+
+            int   qs_cache[qs_cache_size];
+            float d_cache[d_cache_size];
+            const int kb0_next = kb0 + blocks_per_iter;
+            const bool have_next = kb0_next < kb0_stop;
+            if (have_next) {
+                ggml_cuda_mmq_prefetch_tiles_q8_0_rdna35<type, J, fallback>(
+                    x, offset_x + kb0_next, tile_x_max_i, stride_row_x, qs_cache, d_cache);
+            }
+
+            vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+
+            if (have_next) {
+                ggml_cuda_mmq_store_tiles_q8_0_rdna35<type, J, fallback>(
                     tile_x, qs_cache, d_cache);
             }
             __syncthreads();

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -181,7 +181,7 @@ struct ggml_cuda_mmq_config {
     constexpr __device__ int rows_per_warp() const {
 #if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 #if defined(RDNA3_5)
-        if (type == GGML_TYPE_Q4_K && J == 128) {
+        if ((type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q4_0) && J == 128) {
             return 16;
         }
         return J >= 64 && J % 32 == 0 ? 32 : 16;
@@ -814,7 +814,11 @@ static constexpr __device__ ggml_cuda_mmq_util_funcs ggml_cuda_mmq_get_util_func
             return ggml_cuda_mmq_util_funcs(
                 -1,
                 ggml_cuda_mmq_load_tiles_q4_0<type, J, fallback>,
+#if defined(RDNA3_5)
+                ggml_cuda_mmq_vec_dot_q4_0_q8_1_mma_rdna35<type, J, fallback>,
+#else
                 ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma<type, J, fallback, MMQ_Q8_1_DS_LAYOUT_DS4>,
+#endif
                 ggml_cuda_mmq_write_back_mma<type, J, fallback>);
         case GGML_TYPE_Q4_1:
             return ggml_cuda_mmq_util_funcs(
@@ -1093,6 +1097,53 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
             if (have_next) {
                 ggml_cuda_mmq_store_tiles_q4_K_rdna35<type, J, fallback>(
                     tile_x, qs_cache, scales_cache, dm_cache);
+            }
+            __syncthreads();
+        }
+    } else if constexpr (type == GGML_TYPE_Q4_0 && (J == 64 || J == 128)) {
+        constexpr int qs_cache_size = I/nwarps;
+        constexpr int d_cache_size  = 4;
+
+        __syncthreads();
+        load_tiles(x, tile_x, offset_x + kb0_start, tile_x_max_i, stride_row_x);
+        __syncthreads();
+
+        for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
+            const int yk = kb0*qk/ne_block;
+            const int * by0 = y + ncols_y*yk*sz;
+            const int * by1 = y + ncols_y*(yk + 1)*sz;
+
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by0[l];
+            }
+            __syncthreads();
+            vec_dot(tile_x, tile_y, sum, 0);
+
+            __syncthreads();
+#pragma unroll
+            for (int l0 = 0; l0 < J*MMQ_TILE_Y_K; l0 += nwarps*warp_size) {
+                const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by1[l];
+            }
+            __syncthreads();
+
+            int   qs_cache[qs_cache_size];
+            float d_cache[d_cache_size];
+            const int kb0_next = kb0 + blocks_per_iter;
+            const bool have_next = kb0_next < kb0_stop;
+            if (have_next) {
+                ggml_cuda_mmq_prefetch_tiles_q4_0_rdna35<type, J, fallback>(
+                    x, offset_x + kb0_next, tile_x_max_i, stride_row_x, qs_cache, d_cache);
+            }
+
+            vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+
+            if (have_next) {
+                ggml_cuda_mmq_store_tiles_q4_0_rdna35<type, J, fallback>(
+                    tile_x, qs_cache, d_cache);
             }
             __syncthreads();
         }

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1206,7 +1206,7 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
             }
             __syncthreads();
         }
-    } else if constexpr (type == GGML_TYPE_Q8_0 && (J == 96 || J == 128)) {
+    } else if constexpr (type == GGML_TYPE_Q8_0 && J == 128) {
         constexpr int qs_cache_size = 2*(I/nwarps);
         constexpr int d_cache_size  = 4;
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8209,6 +8209,12 @@ static void add_rdna35_mmq_cases(std::vector<std::unique_ptr<test_case>> & test_
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_K, GGML_TYPE_F32, 4096, 16, 4096, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_K, GGML_TYPE_F32, 4096, 1024, 12288, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q6_K, GGML_TYPE_F32, 4096, 128, 12288, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q6_K, GGML_TYPE_F32, 2560, 128, 9216, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_K, GGML_TYPE_F32, 8192, 128, 2560, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_K, GGML_TYPE_F32, 8192, 128, 2560, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_K, GGML_TYPE_F32, 8192, 512, 2560, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_K, GGML_TYPE_F32, 2560, 128, 4096, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_K, GGML_TYPE_F32, 2560, 512, 4096, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 32, 128, 4096, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 32, 128, 4096, {1, 1}, {1, 1}));
     for (int64_t gate_n : {8, 16, 64}) {


### PR DESCRIPTION
1. Fixed ntx size for Q4_0 and Q8_0, which affect several VLMs.
2. Optimized q40, q80, q5k mmq kernels with Nibble-split, Batch J=128 WMMAs, X prefetch, Raise MMQ N cutoff

## Highlights: prefill gains on the shapes the MMQ work targets


| row | quant | base prefill tok/s | opt prefill tok/s | prefill % |
|---|---|---:|---:|---:|
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM † | Q4_0 | 978.0 | 1878.2 | +92.05 |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_multi-image-reasoning † | Q4_0 | 492.2 | 909.6 | +84.80 |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_image-caption-224 † | Q4_0 | 472.1 | 793.6 | +68.11 |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_vqa-448 † | Q4_0 | 489.3 | 821.9 | +67.95 |
| Cosmos-Reason2-8B_Q8_0_GGUF_VLM_prithivMLmods † | Q8_0 | 589.1 | 863.5 | +46.59 |
| Gemma-4-26B-A4B-IT_VLM † | mixed | 701.9 | 834.8 | +18.94 |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_image-caption-224 | Q4_0 | 300.0 | 326.0 | +8.67 |
| Qwen3.5-4B_Q4_K_M_GGUF_mtp_prose | Q4_K_M | 290.1 | 298.9 | +3.04 |


## Q4_0: Latency and throughput

| MUL_MAT shape (m × n × k) | gfx11 (µs) | q4-0-opt (µs) | gfx11 TFLOPS | q4-0-opt TFLOPS | Δ TFLOPS |
|---|---:|---:|---:|---:|---:|
| 1024 × 128 × 4096 | 79.64 | 69.60 | 13.52 | 15.43 | +14.1% |
| 12288 × 32 × 4096 | 248.93 | 235.95 | 12.94 | 13.66 | +5.5% |
| 4096 × 32 × 12288 | 297.90 | 289.49 | 10.83 | 11.12 | +2.7% |
| 64 × 128 × 4096 | 66.91 | 65.53 | 1.00 | 1.02 | +2.0% |
| 4096 × 4 × 4096 | 29.47 | 29.24 | 4.55 | 4.59 | +0.8% |
| 4096 × 32 × 4096 | 103.48 | 103.62 | 10.38 | 10.37 | −0.1% |
| 4096 × 512 × 14336 | 2455.40 | 2457.42 | 24.49 | 24.47 | −0.1% |
| 4096 × 8 × 14336 | 165.00 | 165.21 | 5.70 | 5.69 | −0.2% |
| 4096 × 128 × 12288 | 616.05 | 619.37 | 20.92 | 20.81 | −0.5% |
| 4096 × 128 × 4096 | 198.57 | 199.85 | 21.63 | 21.49 | −0.6% |
| 8192 × 128 × 4096 | 340.09 | 342.86 | 25.26 | 25.05 | −0.8% |
| 12288 × 128 × 4096 | 498.37 | 502.49 | 25.86 | 25.64 | −0.8% |
| 32 × 128 × 4096 | 68.96 | 71.56 | 0.49 | 0.47 | −3.4% |



## Q8_0 Latency and throughput

| MUL_MAT shape (m × n × k) | gfx11 (µs) | q8-0-opt (µs) | gfx11 TFLOPS | q8-0-opt TFLOPS | Δ TFLOPS |
|---|---:|---:|---:|---:|---:|
| 8 × 128 × 4096 | 94.39 | 61.67 | 0.089 | 0.136 | +52.9% |
| 16 × 128 × 4096 | 92.45 | 62.75 | 0.181 | 0.267 | +47.3% |
| 32 × 128 × 4096 | 93.27 | 62.75 | 0.360 | 0.535 | +48.6% |
| 64 × 128 × 4096 | 69.48 | 61.22 | 0.97 | 1.10 | +13.2% |
| 1024 × 128 × 4096 | 69.92 | 67.06 | 15.36 | 16.01 | +4.2% |
| 12288 × 128 × 4096 | 512.75 | 497.07 | 25.13 | 25.92 | +3.2% |
| 4096 × 512 × 14336 | 2462.20 | 2405.64 | 24.42 | 25.00 | +2.4% |
| 8192 × 128 × 4096 | 355.01 | 353.58 | 24.20 | 24.30 | +0.4% |
| 4096 × 4 × 4096 | 35.75 | 35.60 | 3.76 | 3.77 | +0.4% |
| 4096 × 128 × 4096 | 191.53 | 190.98 | 22.43 | 22.49 | +0.3% |
| 4096 × 8 × 14336 | 303.66 | 304.52 | 3.09 | 3.09 | −0.2% |


## Q5_k Latency and throughput
| MUL_MAT shape (m × n × k) | gfx11 (µs) | final (µs) | paired speedup |
|---|---:|---:|---:|
| **8192 × 128 × 2560** | 245.00 | **224.60** | **+9.03%** |
| **8192 × 512 × 2560** | 914.88 | **844.89** | **+8.16%** |
| 2560 × 128 × 4096 | 123.31 | **119.88** | **+2.85%** |
| 1024 × 128 × 4096 | 68.85 | **68.12** | **+1.06%** |
| 4096 × 128 × 4096 | 212.24 | **205.76** | **+3.14%** |



## Model performance
| row | base decode | opt decode | decode % | base prefill | opt prefill | prefill % | status |
|---|---:|---:|---:|---:|---:|---:|---|
| Cosmos-Reason2-8B_Q8_0_GGUF_VLM_prithivMLmods † | 25.93 | 25.93 | +0.00 | 589.10 | 863.54 | +46.59 | PASS |
| GLM-4.7-Flash_Q4_K_M_GGUF_128 | 63.09 | 63.12 | +0.05 | 1057.13 | 1051.74 | -0.51 | PASS |
| Gemma-2B_Q4_K_M_GGUF_128 | 119.41 | 119.50 | +0.07 | 4043.15 | 4077.15 | +0.84 | PASS |
| Gemma-2B_Q4_K_M_GGUF_8000 | 110.54 | 110.55 | +0.01 | 2373.57 | 2375.80 | +0.09 | PASS |
| Gemma-3-12B-IT_Q4_K_M_GGUF_4096 | 25.11 | 25.12 | +0.01 | 839.30 | 838.72 | -0.07 | PASS |
| Gemma-3-12B-IT_Q4_K_M_GGUF_VLM | 27.38 | 27.40 | +0.06 | 275.73 | 276.18 | +0.17 | PASS |
| Gemma-3-4B-IT_VLM | 70.40 | 70.39 | -0.02 | 671.35 | 669.40 | -0.29 | PASS |
| Gemma-3-4B-IT_VLM_document-qa-long-context | 71.90 | 71.93 | +0.05 | 2053.14 | 2055.09 | +0.09 | PASS |
| Gemma-3-4B-IT_VLM_image-caption-224 | 71.04 | 71.00 | -0.06 | 299.55 | 300.04 | +0.16 | PASS |
| Gemma-3-4B-IT_VLM_multi-image-reasoning | 71.16 | 71.07 | -0.13 | 288.01 | 288.75 | +0.26 | PASS |
| Gemma-3-4B-IT_VLM_ocr-1024 | 72.08 | 72.06 | -0.02 | 299.79 | 298.72 | -0.36 | PASS |
| Gemma-3-4B-IT_VLM_text-short-smoke | 68.46 | 70.24 | +2.60 | 392.06 | 401.60 | +2.43 | PASS |
| Gemma-3-4B-IT_VLM_vqa-448 | 69.46 | 69.47 | +0.00 | 293.25 | 293.10 | -0.05 | PASS |
| Gemma-4-12B-it_Q4_K_M_GGUF_128 | 28.61 | 28.60 | -0.05 | 894.05 | 894.08 | +0.00 | PASS |
| Gemma-4-26B-A4B-IT_VLM † | 45.95 | 45.95 | +0.00 | 701.89 | 834.81 | +18.94 | PASS |
| Gemma-4-31B-IT_VLM | 10.66 | 10.67 | +0.07 | 243.01 | 244.01 | +0.41 | PASS |
| Gemma-4-31B-IT_VLM_OpenNav | 10.74 | 10.75 | +0.11 | 230.82 | 230.71 | -0.05 | PASS |
| Gemma-4-E2B-IT_BF16_GGUF_128 | 43.36 | 43.37 | +0.01 | 3122.94 | 3144.47 | +0.69 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM | 100.93 | 100.91 | -0.01 | 975.61 | 974.36 | -0.13 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_document-qa-long-context | 95.81 | 96.14 | +0.35 | 3222.82 | 3229.22 | +0.20 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_image-caption-224 | 92.11 | 92.80 | +0.75 | 470.68 | 521.45 | +10.79 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_multi-image-reasoning | 98.29 | 98.39 | +0.10 | 490.24 | 489.72 | -0.11 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_ocr-1024 | 100.37 | 100.29 | -0.08 | 1014.79 | 1011.64 | -0.31 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_text-short-smoke | 76.05 | 82.05 | +7.89 | 547.43 | 554.27 | +1.25 | PASS |
| Gemma-4-E2B-IT_Q4_0_GGUF_VLM_vqa-448 | 84.35 | 84.60 | +0.30 | 488.40 | 486.61 | -0.37 | PASS |
| Gemma-4-E2B-IT_Q4_K_M_GGUF_128 | 105.74 | 107.75 | +1.91 | 3345.37 | 3343.93 | -0.04 | PASS |
| Gemma-4-E2B-IT_Q4_K_M_GGUF_3968 | 101.51 | 101.44 | -0.06 | 2852.72 | 2871.51 | +0.66 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM | 56.56 | 56.55 | -0.01 | 595.32 | 594.58 | -0.12 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_document-qa-long-context | 55.79 | 55.83 | +0.06 | 1890.10 | 1891.77 | +0.09 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_image-caption-224 | 54.83 | 54.86 | +0.05 | 299.96 | 325.98 | +8.67 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_multi-image-reasoning | 56.51 | 56.48 | -0.05 | 322.82 | 320.78 | -0.63 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_ocr-1024 | 57.01 | 57.11 | +0.18 | 784.52 | 780.89 | -0.46 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_text-short-smoke | 46.88 | 49.84 | +6.31 | 344.66 | 346.05 | +0.40 | PASS |
| Gemma-4-E4B-IT_Q4_0_GGUF_VLM_vqa-448 | 51.87 | 51.77 | -0.17 | 313.58 | 313.17 | -0.13 | PASS |
| Janus-Pro-1B_VLM | 150.62 | 150.53 | -0.06 | 4504.43 | 4500.51 | -0.09 | PASS |
| Janus-Pro-7B_VLM | 41.03 | 41.06 | +0.07 | 1422.28 | 1421.13 | -0.08 | PASS |
| Llama-2-7B_Q4_K_M_GGUF_128 | 49.52 | 49.66 | +0.27 | 1344.48 | 1359.47 | +1.11 | PASS |
| Llama-2-7B_Q4_K_M_GGUF_1920 | 35.78 | 35.79 | +0.02 | 1176.54 | 1183.32 | +0.58 | PASS |
| Llama-3.1-8B-Instruct_Q4_K_M_GGUF_128 | 44.39 | 44.40 | +0.02 | 1301.83 | 1311.66 | +0.76 | PASS |
| MiniCPM-V-2_6_VLM | 46.27 | 46.29 | +0.04 | 589.60 | 589.65 | +0.01 | PASS |
| MiniCPM-o-2_6_VLM | 46.26 | 46.26 | +0.01 | 596.17 | 597.17 | +0.17 | PASS |
| Qwen2.5-0.5B-Instruct_Q4_K_M_GGUF_128 | 347.42 | 278.70 | -19.78 | 10073.25 | 10047.35 | -0.26 | PASS |
| Qwen2.5-0.5B-Instruct_Q4_K_M_GGUF_3968 | 315.82 | 315.09 | -0.23 | 10128.60 | 10143.45 | +0.15 | PASS |
| Qwen2.5-3B-Instruct_Q4_K_M_GGUF_128 | 85.16 | 96.14 | +12.89 | 2886.11 | 2904.97 | +0.65 | PASS |
| Qwen2.5-3B-Instruct_Q4_K_M_GGUF_3968 | 90.10 | 90.06 | -0.05 | 2724.53 | 2730.35 | +0.21 | PASS |
| Qwen2.5-7B-Instruct_Q4_K_M_GGUF_128 | 47.68 | 47.83 | +0.30 | 1519.22 | 1534.45 | +1.00 | PASS |
| Qwen2.5-7B-Instruct_Q4_K_M_GGUF_3968 | 44.51 | 44.51 | +0.00 | 1378.53 | 1381.71 | +0.23 | PASS |
| Qwen2.5-VL-3B-Instruct_VLM | 90.97 | 90.98 | +0.01 | 706.46 | 707.34 | +0.13 | PASS |
| Qwen2.5-VL-7B-Instruct_VLM | 45.56 | 45.56 | +0.02 | 578.14 | 579.04 | +0.16 | PASS |
| Qwen3-1.7B_Q4_K_M_GGUF_128 | 157.95 | 158.11 | +0.10 | 4753.71 | 4825.35 | +1.51 | PASS |
| Qwen3-1.7B_Q4_K_M_GGUF_3968 | 117.78 | 117.76 | -0.02 | 3751.86 | 3772.61 | +0.55 | PASS |
| Qwen3-30B-A3B-Instruct-2507_Q4_K_M_GGUF_128 | 80.56 | 82.20 | +2.03 | 1299.14 | 1279.64 | -1.50 | PASS |
| Qwen3-4B_Q4_K_M_GGUF_128 | 77.46 | 77.57 | +0.14 | 2217.25 | 2237.28 | +0.90 | PASS |
| Qwen3-4B_Q4_K_M_GGUF_3968 | 63.88 | 63.85 | -0.05 | 1761.36 | 1764.74 | +0.19 | PASS |
| Qwen3-8B_Q4_K_M_GGUF_128 | 43.55 | 43.53 | -0.06 | 1279.47 | 1300.98 | +1.68 | PASS |
| Qwen3-8B_Q4_K_M_GGUF_3968 | 38.83 | 38.83 | +0.02 | 1178.57 | 1178.12 | -0.04 | PASS |
| Qwen3-Omni-30B-A3B-Instruct_VLM | 75.77 | 75.67 | -0.14 | 1001.00 | 999.96 | -0.10 | PASS |
| Qwen3-VL-4B-Instruct_VLM | 70.24 | 70.19 | -0.08 | 1251.96 | 1253.68 | +0.14 | PASS |
| Qwen3.5-35B-A3B_Q4_K_M_GGUF_128 | 60.06 | 60.06 | -0.01 | 1306.28 | 1334.22 | +2.14 | PASS |
| Qwen3.5-35B-A3B_VLM | 58.75 | 58.71 | -0.07 | 913.97 | 914.06 | +0.01 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_baseline_code | 65.62 | 65.65 | +0.04 | 473.67 | 473.43 | -0.05 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_baseline_list | 65.16 | 65.19 | +0.05 | 398.70 | 392.04 | -1.67 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_baseline_prose | 65.53 | 65.55 | +0.03 | 335.24 | 334.97 | -0.08 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_mtp_code | 123.21 | 123.13 | -0.06 | 400.40 | 394.11 | -1.57 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_mtp_list | 127.56 | 127.72 | +0.13 | 329.53 | 327.74 | -0.54 | PASS |
| Qwen3.5-4B_Q4_0_GGUF_mtp_prose | 86.25 | 86.43 | +0.21 | 280.33 | 277.13 | -1.14 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_128 | 63.56 | 63.53 | -0.05 | 2007.49 | 2040.28 | +1.63 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_baseline_code | 60.21 | 60.30 | +0.15 | 500.63 | 512.16 | +2.30 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_baseline_list | 59.78 | 59.86 | +0.14 | 420.30 | 415.86 | -1.06 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_baseline_prose | 60.14 | 60.22 | +0.13 | 349.87 | 355.82 | +1.70 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_mtp_code | 106.06 | 106.30 | +0.23 | 418.78 | 424.30 | +1.32 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_mtp_list | 108.43 | 109.40 | +0.90 | 344.44 | 348.96 | +1.31 | PASS |
| Qwen3.5-4B_Q4_K_M_GGUF_mtp_prose | 69.11 | 69.30 | +0.28 | 290.11 | 298.93 | +3.04 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_baseline_code | 39.61 | 39.63 | +0.03 | 322.18 | 325.65 | +1.08 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_baseline_list | 39.47 | 39.46 | -0.02 | 263.33 | 265.83 | +0.95 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_baseline_prose | 39.60 | 39.62 | +0.05 | 226.88 | 228.13 | +0.55 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_mtp_code | 81.59 | 81.56 | -0.04 | 288.74 | 286.55 | -0.76 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_mtp_list | 83.77 | 83.84 | +0.09 | 233.27 | 237.25 | +1.71 | PASS |
| Qwen3.5-9B_Q4_0_GGUF_mtp_prose | 57.48 | 57.43 | -0.07 | 199.80 | 201.26 | +0.73 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_128 | 37.72 | 37.69 | -0.07 | 1202.77 | 1233.84 | +2.58 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_baseline_code | 37.13 | 37.12 | -0.04 | 365.38 | 363.38 | -0.55 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_baseline_list | 36.94 | 36.98 | +0.10 | 297.95 | 299.26 | +0.44 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_baseline_prose | 37.10 | 37.12 | +0.05 | 255.84 | 255.50 | -0.13 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_mtp_code | 68.93 | 68.85 | -0.11 | 318.32 | 320.05 | +0.54 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_mtp_list | 73.08 | 73.36 | +0.38 | 257.84 | 261.18 | +1.29 | PASS |
| Qwen3.5-9B_Q4_K_M_GGUF_mtp_prose | 46.30 | 46.27 | -0.05 | 220.74 | 223.32 | +1.17 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_baseline_code | 13.35 | 13.35 | -0.02 | 112.19 | 111.52 | -0.59 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_baseline_list | 13.32 | 13.32 | -0.03 | 91.44 | 90.15 | -1.41 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_baseline_prose | 13.34 | 13.36 | +0.10 | 77.78 | 77.24 | -0.69 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_mtp_code | 34.41 | 34.43 | +0.06 | 98.48 | 100.12 | +1.67 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_mtp_list | 35.40 | 35.41 | +0.01 | 80.71 | 81.32 | +0.75 | PASS |
| Qwen3.6-27B_Q4_0_GGUF_mtp_prose | 27.97 | 27.96 | -0.04 | 69.12 | 69.31 | +0.27 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_4096 | 12.31 | 12.31 | +0.00 | 380.51 | 383.95 | +0.90 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_baseline_code | 12.44 | 12.45 | +0.06 | 125.76 | 127.77 | +1.60 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_baseline_list | 12.39 | 12.40 | +0.05 | 101.56 | 104.10 | +2.50 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_baseline_prose | 12.33 | 12.45 | +0.99 | 88.44 | 89.63 | +1.34 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_mtp_code | 28.92 | 28.92 | -0.01 | 111.00 | 110.64 | -0.32 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_mtp_list | 29.02 | 29.04 | +0.05 | 90.65 | 90.50 | -0.17 | PASS |
| Qwen3.6-27B_Q4_K_M_GGUF_mtp_prose | 19.55 | 19.55 | +0.01 | 77.26 | 77.49 | +0.30 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_128 | 60.80 | 60.81 | +0.01 | 1307.37 | 1310.59 | +0.25 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_4096 | 59.43 | 59.36 | -0.12 | 1618.74 | 1618.95 | +0.01 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_baseline_code | 59.04 | 59.06 | +0.03 | 299.54 | 296.61 | -0.98 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_baseline_list | 57.95 | 57.94 | -0.01 | 249.96 | 255.58 | +2.25 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_baseline_prose | 58.90 | 58.91 | +0.01 | 216.03 | 214.86 | -0.54 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_mtp_code | 96.47 | 96.52 | +0.05 | 255.57 | 258.13 | +1.00 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_mtp_list | 91.00 | 90.65 | -0.38 | 215.43 | 220.39 | +2.30 | PASS |
| Qwen3.6-35B-A3B_Q4_K_M_GGUF_mtp_prose | 69.40 | 69.42 | +0.02 | 185.25 | 185.34 | +0.05 | PASS |
| Qwen3.6-35B-A3B_VLM_large-context | 54.51 | 54.53 | +0.03 | 1502.56 | 1510.21 | +0.51 | PASS |
| SmolLM2-1.7B-Instruct_F16_GGUF_128 | 53.21 | 53.25 | +0.07 | 4017.24 | 4006.28 | -0.27 | PASS |
| SmolLM2-1.7B-Instruct_F16_GGUF_8000 | 25.42 | 25.43 | +0.01 | 1268.14 | 1268.46 | +0.03 | PASS |
| SmolLM2-1.7B-Instruct_Q4_K_M_GGUF_128 | 161.08 | 161.09 | +0.00 | 4193.60 | 4215.55 | +0.52 | PASS |
| SmolLM2-1.7B-Instruct_Q4_K_M_GGUF_8000 | 37.31 | 37.31 | +0.01 | 1224.73 | 1228.51 | +0.31 | PASS |