### PR TITLE
ggml-hrx: adapt Loom compile configuration

### DIFF
--- a/ggml/src/ggml-hrx/loom-jit.cpp
+++ b/ggml/src/ggml-hrx/loom-jit.cpp
@@ -921,9 +921,7 @@ hrx_status_t ggml_hrx_loom_jit_amdgpu_compile(ggml_hrx_loom_jit_amdgpu *        
     if (options->evaluate_launch_config) {
         compile_options.artifact_flags |= LOOMC_COMPILE_ARTIFACT_FLAG_LAUNCH_CONFIG;
     }
-    compile_options.config.bindings      = config_bindings.get();
-    compile_options.config.binding_count = options->config_binding_count;
-    compile_options.config.flags         = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
+    compile_options.config_flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
     status = loomc_compile_module(jit->compiler, workspace.get(), jit->pass_program, module.get(), &compile_options,
                                   loomc_allocator_system(), result.out());
     if (!loomc_status_is_ok(status)) {


### PR DESCRIPTION
## Motivation

Fixes required to bump [`hrx-graph-develop-v2`](https://github.com/AMD-Ecosystem/llama.cpp/tree/hrx-graph-develop-v2) up to hrx-system: https://github.com/ROCm/hrx-system/commit/7b1df394843d8f1fcfab50cc479d3795effea3eb.

### Breaking changes

| Breaking hrx-system PR | Fix |
| --- | --- |
| https://github.com/ROCm/hrx-system/pull/494 | https://github.com/AaronStGeorge/llama.cpp/commit/2823ea5f55f71a52bae1ee35ee668c0c3e69cae0 |

## Testing

Tested in `ggml-staging-automation` CI with llama.cpp `2823ea5` and hrx-system `7b1df39`.

- Bump PR: https://github.com/ROCm/ggml-staging-automation/pull/57
- Latest run: [link](https://github.com/ROCm/ggml-staging-automation/actions/runs/33750653968).