### PR TITLE
ggml-hrx: adapt to required-inline provider consumption

### DIFF
--- a/ggml/src/ggml-hrx/kernel-corpus/kernels/loom-libs/motifs/llm_attention_qkv_matmul_postops.loom
+++ b/ggml/src/ggml-hrx/kernel-corpus/kernels/loom-libs/motifs/llm_attention_qkv_matmul_postops.loom
@@ -43,7 +43,33 @@ template.def<@llm.attention_qkv.rope_vector4> device @llm_attention_qkv_rope_vec
   %position = scalar.sitofp %position_i32 : i32 to f32
   %theta_packet = vector.load %theta_view[%theta_channel] : view<[%half_head_size]xf32> -> vector<2xf32>
   %freq_factors_packet = vector.load %freq_factors_view[%theta_channel] : view<[%half_head_size]xf32> -> vector<2xf32>
-  %rotated = template.apply<@llm.attention_qkv.normal_rope_vector4>(%position, %theta_packet, %freq_factors_packet, %values) : (f32, vector<2xf32>, vector<2xf32>, vector<4xf32>) -> (vector<4xf32>)
+  // Keep normal RoPE local because nested template providers are consumed
+  // before all shared callers have been expanded.
+  %x0 = vector.extract %values[0] : vector<4xf32> -> f32
+  %y0 = vector.extract %values[1] : vector<4xf32> -> f32
+  %x1 = vector.extract %values[2] : vector<4xf32> -> f32
+  %y1 = vector.extract %values[3] : vector<4xf32> -> f32
+  %x_values = vector.from_elements %x0, %x1 : vector<2xf32>
+  %y_values = vector.from_elements %y0, %y1 : vector<2xf32>
+  %position_vector = vector.splat %position : vector<2xf32>
+  %inverse_two_pi = scalar.constant 0.15915494309189535 : f32
+  %inverse_two_pi_vector = vector.splat %inverse_two_pi : vector<2xf32>
+  %scaled_theta = vector.divf<reassoc|nnan|ninf|nsz|arcp> %theta_packet, %freq_factors_packet : vector<2xf32>
+  %angles = vector.mulf<reassoc|nnan|ninf|nsz|contract> %position_vector, %scaled_theta : vector<2xf32>
+  %turns = vector.mulf<reassoc|nnan|ninf|nsz|contract> %angles, %inverse_two_pi_vector : vector<2xf32>
+  %cosines = vector.costurnsf<afn> %turns : vector<2xf32>
+  %sines = vector.sinturnsf<afn> %turns : vector<2xf32>
+  %x_cosines = vector.mulf<reassoc|nnan|ninf|nsz|contract> %x_values, %cosines : vector<2xf32>
+  %y_sines = vector.mulf<reassoc|nnan|ninf|nsz|contract> %y_values, %sines : vector<2xf32>
+  %x_sines = vector.mulf<reassoc|nnan|ninf|nsz|contract> %x_values, %sines : vector<2xf32>
+  %y_cosines = vector.mulf<reassoc|nnan|ninf|nsz|contract> %y_values, %cosines : vector<2xf32>
+  %rotated_x = vector.subf<reassoc|nnan|ninf|nsz> %x_cosines, %y_sines : vector<2xf32>
+  %rotated_y = vector.addf<reassoc|nnan|ninf|nsz> %x_sines, %y_cosines : vector<2xf32>
+  %rotated_x0 = vector.extract %rotated_x[0] : vector<2xf32> -> f32
+  %rotated_x1 = vector.extract %rotated_x[1] : vector<2xf32> -> f32
+  %rotated_y0 = vector.extract %rotated_y[0] : vector<2xf32> -> f32
+  %rotated_y1 = vector.extract %rotated_y[1] : vector<2xf32> -> f32
+  %rotated = vector.from_elements %rotated_x0, %rotated_y0, %rotated_x1, %rotated_y1 : vector<4xf32>
   template.return %rotated : vector<4xf32>
 }
 
@@ -51,13 +77,15 @@ template.def<@llm.attention_qkv.store_query_vector4> device @llm_attention_qkv_s
   %token_count = index.assume %token_count0 [range(%token_count0, 1, 2048)] : index
   %head_size = index.assume %head_size0 [range(%head_size0, 4, 1024), mul(%head_size0, 4)] : index
   %head_count = index.assume %head_count0 [range(%head_count0, 1, 64)] : index
+  %c1 = index.constant 1 : index
   %c0_offset = index.constant 0 : offset
   %head = index.div %channel, %head_size : index
   %head_channel = index.rem %channel, %head_size : index
   %token, %launch_token_count = index.assume %token0, %token_count [lt(%token0, %token_count)] : index, index
   %output_noalias = buffer.assume.noalias %output : buffer
   %output_view = buffer.view %output_noalias[%c0_offset] : buffer -> view<[%token_count]x[%head_count]x[%head_size]xf32>
-  vector.store %values, %output_view[%token, %head, %head_channel] : vector<4xf32>, view<[%token_count]x[%head_count]x[%head_size]xf32>
+  %mask = vector.mask.range [%head_channel to %head_size step %c1] : index -> vector<4xi1>
+  vector.store.mask %values, %output_view[%token, %head, %head_channel], %mask : vector<4xf32>, view<[%token_count]x[%head_count]x[%head_size]xf32>, vector<4xi1>
   template.return
 }
 

--- a/ggml/src/ggml-hrx/kernel-corpus/kernels/loom-libs/motifs/unary_f32_apply.loom
+++ b/ggml/src/ggml-hrx/kernel-corpus/kernels/loom-libs/motifs/unary_f32_apply.loom
@@ -5,7 +5,7 @@ template.decl @ggml.unary_f32.apply(%op: index, %value: f32) -> (f32)
 
 template.decl @ggml.unary_f32.apply_vector4(%op: index, %values: vector<4xf32>) -> (vector<4xf32>)
 
-template.def<@ggml.unary_f32.apply> device priority(1) @ggml_unary_f32_apply(%op: index, %value: f32) -> (f32) {
+func.def retain @ggml_unary_f32_apply_impl(%op: index, %value: f32) -> (f32) {
   %c0_f32 = scalar.constant 0.0 : f32
   %c0_5_f32 = scalar.constant 0.5 : f32
   %c1_f32 = scalar.constant 1.0 : f32
@@ -213,6 +213,11 @@ template.def<@ggml.unary_f32.apply> device priority(1) @ggml_unary_f32_apply(%op
   %op_identity = index.constant 23 : index
   %is_identity = index.cmp eq, %op, %op_identity : index
   %result = scf.select %is_identity, %value, %log_selected : f32
+  func.return %result : f32
+}
+
+template.def<@ggml.unary_f32.apply> device priority(1) @ggml_unary_f32_apply(%op: index, %value: f32) -> (f32) {
+  %result = func.call @ggml_unary_f32_apply_impl(%op, %value) : (index, f32) -> (f32)
   template.return %result : f32
 }
 
@@ -221,10 +226,10 @@ template.def<@ggml.unary_f32.apply_vector4> device priority(1) @ggml_unary_f32_a
   %value1 = vector.extract %values[1] : vector<4xf32> -> f32
   %value2 = vector.extract %values[2] : vector<4xf32> -> f32
   %value3 = vector.extract %values[3] : vector<4xf32> -> f32
-  %result0 = template.apply<@ggml.unary_f32.apply>(%op, %value0) : (index, f32) -> (f32)
-  %result1 = template.apply<@ggml.unary_f32.apply>(%op, %value1) : (index, f32) -> (f32)
-  %result2 = template.apply<@ggml.unary_f32.apply>(%op, %value2) : (index, f32) -> (f32)
-  %result3 = template.apply<@ggml.unary_f32.apply>(%op, %value3) : (index, f32) -> (f32)
+  %result0 = func.call @ggml_unary_f32_apply_impl(%op, %value0) : (index, f32) -> (f32)
+  %result1 = func.call @ggml_unary_f32_apply_impl(%op, %value1) : (index, f32) -> (f32)
+  %result2 = func.call @ggml_unary_f32_apply_impl(%op, %value2) : (index, f32) -> (f32)
+  %result3 = func.call @ggml_unary_f32_apply_impl(%op, %value3) : (index, f32) -> (f32)
   %result = vector.from_elements %result0, %result1, %result2, %result3 : vector<4xf32>
   template.return %result : vector<4xf32>
 }

--- a/ggml/src/ggml-hrx/kernel-corpus/kernels/qwen_moe/qwen3_moe/batched_decode_gate_up_q4k.loom
+++ b/ggml/src/ggml-hrx/kernel-corpus/kernels/qwen_moe/qwen3_moe/batched_decode_gate_up_q4k.loom
@@ -26,8 +26,6 @@ config.decl @qwen3_moe.batched_decode.rows2_descriptor_capacity : %value: index 
 
 kernel.decl @ggml_quantize_q8_1_x4_f32(%token_count$8: index, %input_size$9: index) launch(%token_count$10: index, %input_size$11: index, %input: buffer, %output: buffer)
 
-func.decl @qwen3_moe_q4k_chunk_pair_global(%weight: buffer, %row_byte_base: offset, %q4_block: index, %q4_group_pair: index, %q4_half: index, %header_words: vector<4xi32>) -> (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32)
-
 func.decl @qwen3_moe_q4k_q8_1_dot(%q4_values: vector<16xi8>, %d_scale: f32, %dmin_scale: f32, %q8_values: vector<16xi8>, %q8_d: f32, %q8_s: f32) -> (f32)
 
 func.decl @qwen3_moe_unpack_batched_decode_expert_descriptor(%descriptor: vector<4xi32>) -> (index, index, index)
@@ -51,6 +49,7 @@ func.def inline @qwen3_moe_batched_decode_q4k_rows2_lane(%input_size: index, %we
   %c1023 = index.constant 1023 : index
   %c1024 = index.constant 1024 : index
   %q4_block_bytes = index.constant 144 : offset
+  %q4_code_byte_add = index.constant 16 : offset
   %q8_group_bytes = index.constant 144 : offset
   %q8_payload_byte_add = index.constant 16 : offset
   %c0_f32 = scalar.constant 0.0 : f32
@@ -130,7 +129,84 @@ func.def inline @qwen3_moe_batched_decode_q4k_rows2_lane(%input_size: index, %we
       %q4_block_byte_base = index.add %weight_row_byte_base, %q4_block_byte_add : offset
       %header_view = buffer.view %weight[%q4_block_byte_base] : buffer -> view<4xi32>
       %header_words = vector.load %header_view[0] : view<4xi32> -> vector<4xi32>
-      %q4_low, %low_d_scale, %low_dmin_scale, %q4_high, %high_d_scale, %high_dmin_scale = func.call @qwen3_moe_q4k_chunk_pair_global(%weight, %weight_row_byte_base, %q4_block, %q4_group_pair, %q4_half, %header_words) : (buffer, offset, index, index, index, vector<4xi32>) -> (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32)
+      // This buffer-dependent decode cannot be retained as a concrete device
+      // helper, so keep it local to the shared caller.
+      %q4_code_byte_base = index.add %q4_block_byte_base, %q4_code_byte_add : offset
+      %q4_code_view = buffer.view %weight[%q4_code_byte_base] : buffer -> view<32xi32>
+      %pair_code_base = index.mul %q4_group_pair, %c8 : index
+      %half_code_add = index.mul %q4_half, %c4 : index
+      %code_index0 = index.add %pair_code_base, %half_code_add : index
+      %code_index = index.assume %code_index0 [range(%code_index0, 0, 28)] : index
+      %packed_codes = vector.load %q4_code_view[%code_index] : view<32xi32> -> vector<4xi32>
+      %nibble_mask = vector.constant 252645135 : vector<4xi32>
+      %q4_low_codes = vector.andi %packed_codes, %nibble_mask : vector<4xi32>
+      %c4_i32 = scalar.constant 4 : i32
+      %c4_i32v = vector.splat %c4_i32 : vector<4xi32>
+      %q4_high_shifted = vector.shrui %packed_codes, %c4_i32v : vector<4xi32>
+      %q4_high_codes = vector.andi %q4_high_shifted, %nibble_mask : vector<4xi32>
+      %q4_low = vector.bitcast %q4_low_codes : vector<4xi32> to vector<16xi8>
+      %q4_high = vector.bitcast %q4_high_codes : vector<4xi32> to vector<16xi8>
+      %header_halves = vector.bitcast %header_words : vector<4xi32> to vector<8xf16>
+      %d_f16 = vector.extract %header_halves[0] : vector<8xf16> -> f16
+      %dmin_f16 = vector.extract %header_halves[1] : vector<8xf16> -> f16
+      %scale0 = vector.extract %header_words[1] : vector<4xi32> -> i32
+      %scale1 = vector.extract %header_words[2] : vector<4xi32> -> i32
+      %scale2 = vector.extract %header_words[3] : vector<4xi32> -> i32
+      %d = scalar.extf %d_f16 : f16 to f32
+      %dmin = scalar.extf %dmin_f16 : f16 to f32
+      %low_group = index.mul %q4_group_pair, %c2 : index
+      %high_group = index.add %low_group, %c1 : index
+      %c2_i32 = scalar.constant 2 : i32
+      %c15_i32 = scalar.constant 15 : i32
+      %c48_i32 = scalar.constant 48 : i32
+      %low_is_low_group = index.cmp ult, %low_group, %c4 : index
+      %low_scale_lane = index.rem %low_group, %c4 : index
+      %low_scale_shift_index = index.mul %low_scale_lane, %c8 : index
+      %low_scale_shift = index.cast %low_scale_shift_index : index to i32
+      %low_high_shift = scalar.addi %low_scale_shift, %c2_i32 : i32
+      %low_minimum_shift = scalar.addi %low_scale_shift, %c4_i32 : i32
+      %low_selected_scale_source = scf.select %low_is_low_group, %scale0, %scale2 : i32
+      %low_selected_minimum_source = scf.select %low_is_low_group, %scale1, %scale2 : i32
+      %low_selected_scale_high_shift = scf.select %low_is_low_group, %low_scale_shift, %low_high_shift : i32
+      %low_selected_minimum_low_shift = scf.select %low_is_low_group, %low_scale_shift, %low_minimum_shift : i32
+      %low_scale_low0 = scalar.shrui %low_selected_scale_source, %low_scale_shift : i32
+      %low_scale_low = scalar.andi %low_scale_low0, %c15_i32 : i32
+      %low_scale_high0 = scalar.shrui %scale0, %low_selected_scale_high_shift : i32
+      %low_scale_high = scalar.andi %low_scale_high0, %c48_i32 : i32
+      %low_scale = scalar.ori %low_scale_low, %low_scale_high : i32
+      %low_minimum_low0 = scalar.shrui %low_selected_minimum_source, %low_selected_minimum_low_shift : i32
+      %low_minimum_low = scalar.andi %low_minimum_low0, %c15_i32 : i32
+      %low_minimum_high0 = scalar.shrui %scale1, %low_selected_scale_high_shift : i32
+      %low_minimum_high = scalar.andi %low_minimum_high0, %c48_i32 : i32
+      %low_minimum = scalar.ori %low_minimum_low, %low_minimum_high : i32
+      %high_is_low_group = index.cmp ult, %high_group, %c4 : index
+      %high_scale_lane = index.rem %high_group, %c4 : index
+      %high_scale_shift_index = index.mul %high_scale_lane, %c8 : index
+      %high_scale_shift = index.cast %high_scale_shift_index : index to i32
+      %high_high_shift = scalar.addi %high_scale_shift, %c2_i32 : i32
+      %high_minimum_shift = scalar.addi %high_scale_shift, %c4_i32 : i32
+      %high_selected_scale_source = scf.select %high_is_low_group, %scale0, %scale2 : i32
+      %high_selected_minimum_source = scf.select %high_is_low_group, %scale1, %scale2 : i32
+      %high_selected_scale_high_shift = scf.select %high_is_low_group, %high_scale_shift, %high_high_shift : i32
+      %high_selected_minimum_low_shift = scf.select %high_is_low_group, %high_scale_shift, %high_minimum_shift : i32
+      %high_scale_low0 = scalar.shrui %high_selected_scale_source, %high_scale_shift : i32
+      %high_scale_low = scalar.andi %high_scale_low0, %c15_i32 : i32
+      %high_scale_high0 = scalar.shrui %scale0, %high_selected_scale_high_shift : i32
+      %high_scale_high = scalar.andi %high_scale_high0, %c48_i32 : i32
+      %high_scale = scalar.ori %high_scale_low, %high_scale_high : i32
+      %high_minimum_low0 = scalar.shrui %high_selected_minimum_source, %high_selected_minimum_low_shift : i32
+      %high_minimum_low = scalar.andi %high_minimum_low0, %c15_i32 : i32
+      %high_minimum_high0 = scalar.shrui %scale1, %high_selected_scale_high_shift : i32
+      %high_minimum_high = scalar.andi %high_minimum_high0, %c48_i32 : i32
+      %high_minimum = scalar.ori %high_minimum_low, %high_minimum_high : i32
+      %low_scale_f32 = scalar.uitofp %low_scale : i32 to f32
+      %low_minimum_f32 = scalar.uitofp %low_minimum : i32 to f32
+      %high_scale_f32 = scalar.uitofp %high_scale : i32 to f32
+      %high_minimum_f32 = scalar.uitofp %high_minimum : i32 to f32
+      %low_d_scale = scalar.mulf %d, %low_scale_f32 : f32
+      %low_dmin_scale = scalar.mulf %dmin, %low_minimum_f32 : f32
+      %high_d_scale = scalar.mulf %d, %high_scale_f32 : f32
+      %high_dmin_scale = scalar.mulf %dmin, %high_minimum_f32 : f32
       %row0_low = func.call @qwen3_moe_q4k_q8_1_dot(%q4_low, %low_d_scale, %low_dmin_scale, %q8_low_values0, %q8_low_d0, %q8_low_s0) : (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32) -> (f32)
       %row0_high = func.call @qwen3_moe_q4k_q8_1_dot(%q4_high, %high_d_scale, %high_dmin_scale, %q8_high_values0, %q8_high_d0, %q8_high_s0) : (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32) -> (f32)
       %row1_low = func.call @qwen3_moe_q4k_q8_1_dot(%q4_low, %low_d_scale, %low_dmin_scale, %q8_low_values1, %q8_low_d1, %q8_low_s1) : (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32) -> (f32)

--- a/ggml/src/ggml-hrx/kernel-corpus/kernels/qwen_moe/qwen3_moe/routed_gate_up_swiglu_q4k.loom
+++ b/ggml/src/ggml-hrx/kernel-corpus/kernels/qwen_moe/qwen3_moe/routed_gate_up_swiglu_q4k.loom
@@ -286,7 +286,9 @@ func.def inline @qwen3_moe_q4k_chunk_pair_global(%weight: buffer, %row_byte_base
 
 // Contracts one decoded Q4_K half-group with a Q8_1 half-block. Both
 // half-groups apply half of the Q8_1 block-sum correction.
-func.def inline @qwen3_moe_q4k_q8_1_dot(%q4_values: vector<16xi8>, %d_scale: f32, %dmin_scale: f32, %q8_values: vector<16xi8>, %q8_d: f32, %q8_s: f32) -> (f32) {
+// Keep this register-only leaf concrete until target-required inlining expands
+// every shared caller.
+func.def retain @qwen3_moe_q4k_q8_1_dot(%q4_values: vector<16xi8>, %d_scale: f32, %dmin_scale: f32, %q8_values: vector<16xi8>, %q8_d: f32, %q8_s: f32) -> (f32) {
   %c0_i32 = scalar.constant 0 : i32
   %c0_i32v = vector.constant 0 : vector<4xi32>
   %half_f32 = scalar.constant 0.5 : f32
@@ -417,6 +419,7 @@ func.def inline @qwen3_moe_q4k_q8_1_x4_paired_block_lane(%input_size: index, %we
   %c128 = index.constant 128 : index
   %c256 = index.constant 256 : index
   %q4_block_bytes = index.constant 144 : offset
+  %q4_code_byte_add = index.constant 16 : offset
   %q8_group_bytes = index.constant 144 : offset
   %q8_payload_byte_add = index.constant 16 : offset
   %q4_block_count = index.div %bounded_input_size, %c256 : index
@@ -468,7 +471,84 @@ func.def inline @qwen3_moe_q4k_q8_1_x4_paired_block_lane(%input_size: index, %we
   %q4_block_byte_base = index.add %weight_row_byte_base, %q4_block_byte_add : offset
   %q4_header_view = buffer.view %weight[%q4_block_byte_base] : buffer -> view<4xi32>
   %q4_header_words = vector.load %q4_header_view[0] : view<4xi32> -> vector<4xi32>
-  %q4_low, %low_d_scale, %low_dmin_scale, %q4_high, %high_d_scale, %high_dmin_scale = func.call @qwen3_moe_q4k_chunk_pair_global(%weight, %weight_row_byte_base, %bounded_q4_block, %q4_group_pair, %q4_half, %q4_header_words) : (buffer, offset, index, index, index, vector<4xi32>) -> (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32)
+  // This buffer-dependent decode cannot be retained as a concrete device
+  // helper, so keep it local to the shared caller.
+  %q4_code_byte_base = index.add %q4_block_byte_base, %q4_code_byte_add : offset
+  %q4_code_view = buffer.view %weight[%q4_code_byte_base] : buffer -> view<32xi32>
+  %pair_code_base = index.mul %q4_group_pair, %c8 : index
+  %half_code_add = index.mul %q4_half, %c4 : index
+  %code_index0 = index.add %pair_code_base, %half_code_add : index
+  %code_index = index.assume %code_index0 [range(%code_index0, 0, 28)] : index
+  %packed_codes = vector.load %q4_code_view[%code_index] : view<32xi32> -> vector<4xi32>
+  %nibble_mask = vector.constant 252645135 : vector<4xi32>
+  %q4_low_codes = vector.andi %packed_codes, %nibble_mask : vector<4xi32>
+  %c4_i32 = scalar.constant 4 : i32
+  %c4_i32v = vector.splat %c4_i32 : vector<4xi32>
+  %q4_high_shifted = vector.shrui %packed_codes, %c4_i32v : vector<4xi32>
+  %q4_high_codes = vector.andi %q4_high_shifted, %nibble_mask : vector<4xi32>
+  %q4_low = vector.bitcast %q4_low_codes : vector<4xi32> to vector<16xi8>
+  %q4_high = vector.bitcast %q4_high_codes : vector<4xi32> to vector<16xi8>
+  %header_halves = vector.bitcast %q4_header_words : vector<4xi32> to vector<8xf16>
+  %d_f16 = vector.extract %header_halves[0] : vector<8xf16> -> f16
+  %dmin_f16 = vector.extract %header_halves[1] : vector<8xf16> -> f16
+  %scale0 = vector.extract %q4_header_words[1] : vector<4xi32> -> i32
+  %scale1 = vector.extract %q4_header_words[2] : vector<4xi32> -> i32
+  %scale2 = vector.extract %q4_header_words[3] : vector<4xi32> -> i32
+  %d = scalar.extf %d_f16 : f16 to f32
+  %dmin = scalar.extf %dmin_f16 : f16 to f32
+  %low_group = index.mul %q4_group_pair, %c2 : index
+  %high_group = index.add %low_group, %c1 : index
+  %c2_i32 = scalar.constant 2 : i32
+  %c15_i32 = scalar.constant 15 : i32
+  %c48_i32 = scalar.constant 48 : i32
+  %low_is_low_group = index.cmp ult, %low_group, %c4 : index
+  %low_scale_lane = index.rem %low_group, %c4 : index
+  %low_scale_shift_index = index.mul %low_scale_lane, %c8 : index
+  %low_scale_shift = index.cast %low_scale_shift_index : index to i32
+  %low_high_shift = scalar.addi %low_scale_shift, %c2_i32 : i32
+  %low_minimum_shift = scalar.addi %low_scale_shift, %c4_i32 : i32
+  %low_selected_scale_source = scf.select %low_is_low_group, %scale0, %scale2 : i32
+  %low_selected_minimum_source = scf.select %low_is_low_group, %scale1, %scale2 : i32
+  %low_selected_scale_high_shift = scf.select %low_is_low_group, %low_scale_shift, %low_high_shift : i32
+  %low_selected_minimum_low_shift = scf.select %low_is_low_group, %low_scale_shift, %low_minimum_shift : i32
+  %low_scale_low0 = scalar.shrui %low_selected_scale_source, %low_scale_shift : i32
+  %low_scale_low = scalar.andi %low_scale_low0, %c15_i32 : i32
+  %low_scale_high0 = scalar.shrui %scale0, %low_selected_scale_high_shift : i32
+  %low_scale_high = scalar.andi %low_scale_high0, %c48_i32 : i32
+  %low_scale = scalar.ori %low_scale_low, %low_scale_high : i32
+  %low_minimum_low0 = scalar.shrui %low_selected_minimum_source, %low_selected_minimum_low_shift : i32
+  %low_minimum_low = scalar.andi %low_minimum_low0, %c15_i32 : i32
+  %low_minimum_high0 = scalar.shrui %scale1, %low_selected_scale_high_shift : i32
+  %low_minimum_high = scalar.andi %low_minimum_high0, %c48_i32 : i32
+  %low_minimum = scalar.ori %low_minimum_low, %low_minimum_high : i32
+  %high_is_low_group = index.cmp ult, %high_group, %c4 : index
+  %high_scale_lane = index.rem %high_group, %c4 : index
+  %high_scale_shift_index = index.mul %high_scale_lane, %c8 : index
+  %high_scale_shift = index.cast %high_scale_shift_index : index to i32
+  %high_high_shift = scalar.addi %high_scale_shift, %c2_i32 : i32
+  %high_minimum_shift = scalar.addi %high_scale_shift, %c4_i32 : i32
+  %high_selected_scale_source = scf.select %high_is_low_group, %scale0, %scale2 : i32
+  %high_selected_minimum_source = scf.select %high_is_low_group, %scale1, %scale2 : i32
+  %high_selected_scale_high_shift = scf.select %high_is_low_group, %high_scale_shift, %high_high_shift : i32
+  %high_selected_minimum_low_shift = scf.select %high_is_low_group, %high_scale_shift, %high_minimum_shift : i32
+  %high_scale_low0 = scalar.shrui %high_selected_scale_source, %high_scale_shift : i32
+  %high_scale_low = scalar.andi %high_scale_low0, %c15_i32 : i32
+  %high_scale_high0 = scalar.shrui %scale0, %high_selected_scale_high_shift : i32
+  %high_scale_high = scalar.andi %high_scale_high0, %c48_i32 : i32
+  %high_scale = scalar.ori %high_scale_low, %high_scale_high : i32
+  %high_minimum_low0 = scalar.shrui %high_selected_minimum_source, %high_selected_minimum_low_shift : i32
+  %high_minimum_low = scalar.andi %high_minimum_low0, %c15_i32 : i32
+  %high_minimum_high0 = scalar.shrui %scale1, %high_selected_scale_high_shift : i32
+  %high_minimum_high = scalar.andi %high_minimum_high0, %c48_i32 : i32
+  %high_minimum = scalar.ori %high_minimum_low, %high_minimum_high : i32
+  %low_scale_f32 = scalar.uitofp %low_scale : i32 to f32
+  %low_minimum_f32 = scalar.uitofp %low_minimum : i32 to f32
+  %high_scale_f32 = scalar.uitofp %high_scale : i32 to f32
+  %high_minimum_f32 = scalar.uitofp %high_minimum : i32 to f32
+  %low_d_scale = scalar.mulf %d, %low_scale_f32 : f32
+  %low_dmin_scale = scalar.mulf %dmin, %low_minimum_f32 : f32
+  %high_d_scale = scalar.mulf %d, %high_scale_f32 : f32
+  %high_dmin_scale = scalar.mulf %dmin, %high_minimum_f32 : f32
   %low = func.call @qwen3_moe_q4k_q8_1_dot(%q4_low, %low_d_scale, %low_dmin_scale, %q8_low_values, %q8_low_d, %q8_low_s) : (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32) -> (f32)
   %high = func.call @qwen3_moe_q4k_q8_1_dot(%q4_high, %high_d_scale, %high_dmin_scale, %q8_high_values, %q8_high_d, %q8_high_s) : (vector<16xi8>, f32, f32, vector<16xi8>, f32, f32) -> (f32)
   %pair = scalar.addf %low, %high : f32


### PR DESCRIPTION
## Motivation

Fixes required to bump [`hrx-graph-develop-v2`](https://github.com/AMD-Ecosystem/llama.cpp/tree/hrx-graph-develop-v2) up to hrx-system: https://github.com/ROCm/hrx-system/commit/6bcd5a4ff111fa5bf160ab9f4592ca8e7cc810b1.

### Breaking changes

| Breaking hrx-system PR | Fix |
| --- | --- |
| https://github.com/ROCm/hrx-system/pull/529 | https://github.com/AaronStGeorge/llama.cpp/commit/9e8fc44b39abc69402ec0dabc70790afdb39b8f7 |
| https://github.com/ROCm/hrx-system/pull/529 | https://github.com/AaronStGeorge/llama.cpp/commit/754c3811ccff02712bd47b58518f4c465e5349d5 |

## Testing

Tested in `ggml-staging-automation` CI with llama.cpp `754c381` and hrx-system `6bcd5a4`.

- Bump PR: https://github.com/ROCm/ggml-staging-automation/pull/61
- Latest run: [link](https://github.com/ROCm/ggml-staging-automation/actions/runs/34133430449).
