### PR TITLE
Fix: Return 'invalid_prompt' error type for invalid token IDs

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -52,6 +52,10 @@ json format_error_response(const std::string & message, const enum error_type ty
             type_str = "exceed_context_size_error";
             code = 400;
             break;
+        case ERROR_TYPE_INVALID_PROMPT:
+            type_str = "invalid_prompt";
+            code = 400;
+            break;
     }
     return json {
         {"code", code},

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -62,6 +62,7 @@ enum error_type {
     ERROR_TYPE_UNAVAILABLE, // custom error
     ERROR_TYPE_NOT_SUPPORTED, // custom error
     ERROR_TYPE_EXCEED_CONTEXT_SIZE, // custom error
+    ERROR_TYPE_INVALID_PROMPT, // custom error - for bad token IDs in prompt array
 };
 
 // thin wrapper around common_grammar_trigger with (de)serialization functions

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1709,7 +1709,7 @@ private:
         }
 
         if (!task.tokens.validate(ctx_tgt)) {
-            send_error(task, "Prompt contains invalid tokens", ERROR_TYPE_INVALID_REQUEST);
+            send_error(task, "Prompt contains invalid tokens", ERROR_TYPE_INVALID_PROMPT);
             return false;
         }
 
@@ -2172,7 +2172,7 @@ private:
             task.cli_prompt.clear();
             task.cli_files.clear();
         } catch (const std::exception & e) {
-            send_error(task, std::string("Failed to format input: ") + e.what(), ERROR_TYPE_INVALID_REQUEST);
+            send_error(task, std::string("Failed to format input: ") + e.what(), ERROR_TYPE_INVALID_PROMPT);
             return false;
         }
         return true;


### PR DESCRIPTION

## Overview

RVT (ROCm Validation Tool) Spec 2.9 requires POST /v1/completions with an integer-array prompt to reject invalid token IDs with HTTP 400 and error.type "invalid_prompt".

Previously, invalid token IDs correctly returned HTTP 400 but used error.type "invalid_request_error" instead of the spec-required "invalid_prompt".

## Additional information

Changes:
- Add ERROR_TYPE_INVALID_PROMPT to enum error_type (server-common.h)
- Map it to "invalid_prompt" / HTTP 400 (server-common.cpp)
- Use it for range + type validation errors (server-context.cpp)

Tested with a local script (one-time; likely not worth checking in).

Invalid token types are now properly rejected:
- Out-of-vocabulary (t >= n_vocab)
- Negative values (t < -1)
- LLAMA_TOKEN_NULL (-1) without valid media chunk
- Non-integer JSON types (float, string, null, boolean)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used to create the test script and to draft the commit message (reviewed and finalized by Callum Mitchell)