### PR TITLE
[AIESW-41278] server : make chat logprobs response OpenAI-compatible

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1117,7 +1117,6 @@ json oaicompat_chat_params_parse(
 
     auto tools = json_value(body, "tools", json());
     auto has_tools = tools.is_array() && !tools.empty();
-    auto stream = json_value(body, "stream", false);
     auto tool_choice = json_value(body, "tool_choice", std::string("auto"));
 
     if (!opt.use_jinja) {
@@ -1347,11 +1346,11 @@ json oaicompat_chat_params_parse(
     }
 
     // Handle "logprobs" field
-    // TODO: The response format of this option is not yet OAI-compatible, but seems like no one really using it; We may need to fix it in the future
+    // Response is OpenAI-modern shape (choices[].logprobs.content[]); each entry also carries the
+    // integer token id, which is an intentional extension required by RVT scoring. With tools, the
+    // streaming path emits per-token logprobs for all tokens (including tool-call tokens), matching
+    // the non-streaming path.
     if (json_value(body, "logprobs", false)) {
-        if (has_tools && stream) {
-            throw std::invalid_argument("logprobs is not supported with tools + stream");
-        }
         llama_params["n_probs"] = json_value(body, "top_logprobs", 20);
     } else if (body.contains("top_logprobs") && !body.at("top_logprobs").is_null()) {
         throw std::invalid_argument("top_logprobs requires logprobs to be set to true");

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -319,6 +319,49 @@ def test_completion_without_tool_call_fast(template_name: str, n_predict: int, t
     do_test_completion_without_tool_call(server, n_predict, tools, tool_choice, stream=stream == CompletionMode.STREAMED)
 
 
+def test_logprobs_with_tools_stream():
+    # Regression: tools + stream + logprobs used to be rejected with a 400. It is now allowed and,
+    # matching the non-streaming path, emits per-token logprobs (including tool-call tokens) in the
+    # OpenAI-modern shape, retaining the integer token id required by RVT scoring.
+    global server
+    server.jinja = True
+    server.n_predict = 128
+    server.chat_template_file = '../../../models/templates/meta-llama-Llama-3.3-70B-Instruct.jinja'
+    server.start()
+
+    seen_logprobs = False
+    for chunk in server.make_stream_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 128,
+        "messages": [
+            {"role": "system", "content": "You are a coding assistant."},
+            {"role": "user", "content": "Write an example"},
+        ],
+        "tools": [TEST_TOOL],
+        "tool_choice": "required",
+        "parallel_tool_calls": False,
+        "stream": True,
+        "logprobs": True,
+        "top_logprobs": 5,
+    }):
+        if not chunk["choices"]:
+            continue
+        logprobs = chunk["choices"][0].get("logprobs")
+        if not logprobs:
+            continue
+        for entry in logprobs["content"]:
+            seen_logprobs = True
+            assert "id" in entry and isinstance(entry["id"], int)
+            assert "token" in entry
+            assert entry["logprob"] <= 0.0
+            assert entry["bytes"] is not None
+            assert len(entry["top_logprobs"]) > 0
+            for top in entry["top_logprobs"]:
+                assert "id" in top and isinstance(top["id"], int)
+                assert "token" in top
+                assert top["logprob"] <= 0.0
+    assert seen_logprobs, "Expected at least one logprobs entry across the stream"
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("stream", [CompletionMode.NORMAL, CompletionMode.STREAMED])
 @pytest.mark.parametrize("template_name,n_predict,tools,tool_choice", [


### PR DESCRIPTION
## Overview

This pr targets llama-server's chat functionality: removes the throw when stream + tool + logprobs is requested and add a unit test. Also replaces the stale OAI-incompatible comment.

The chat logprobs response is already OAI compatible, so no change is made to the response format.

The streaming path now mirrors the existing non-streaming behavior — it emits per-token logprobs for all tokens, including tool-call tokens.

## Additional information

RVTech (RVT) SoC Vendor AI Requirements / AI Chat Completion Test Server Specification v1.3. Compliance audit of upstream llama-server (ROCm/llama.cpp) found this gap. Full audit: https://amd.atlassian.net/wiki/spaces/MLSE/pages/1839910115

In RVT's spec, they asks for: "`choices[].message.logprobs` (returned when `logprobs: true`)"
However, this contradicts with the [OpenAI chat completion schema](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create). Per the documentation from OpenAI Python SDK, the expected schema is `choices[].logprobs` (`logprobs` is at the same level as `message`).
As RVT's spec specifies that "the endpoint shall be callable, without modification, by the official OpenAI Python SDK" (Section 6), suspecting that `choices[].message.logprobs` is a typo in the spec and needs to confirm with RVT.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. AI was used when planning and drafting the pr.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
